### PR TITLE
Implementa cadastro de atributos dinamicos

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,6 +9,8 @@ import { authMiddleware } from './middlewares/auth.middleware';
 import { setupSwagger } from './swagger';
 import siscomexRoutes from './routes/siscomex.routes';
 import operadorEstrangeiroRoutes from './routes/operador-estrangeiro.routes';
+import produtoRoutes from './routes/produto.routes';
+import atributoRoutes from './routes/atributo.routes';
 import { Router } from 'express';
 import { API_PREFIX } from './config';
 
@@ -32,6 +34,10 @@ apiRouter.use('/catalogos', catalogoRoutes);
 
 // Rotas SISCOMEX (protegidas)
 apiRouter.use('/siscomex', siscomexRoutes);
+
+// Rotas de produtos e atributos (protegidas)
+apiRouter.use('/produtos', produtoRoutes);
+apiRouter.use('/estruturas', atributoRoutes);
 
 // Rotas de operadores estrangeiros (protegidas)
 apiRouter.use('/operadores-estrangeiros', operadorEstrangeiroRoutes);

--- a/backend/src/controllers/atributo.controller.ts
+++ b/backend/src/controllers/atributo.controller.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express';
+import { EstruturaService } from '../services/estrutura.service';
+
+const estruturaService = new EstruturaService();
+
+export function obterEstruturaPorNcm(req: Request, res: Response) {
+  const { ncm } = req.params;
+  const estrutura = estruturaService.obterPorNcm(ncm);
+  if (!estrutura) {
+    return res.status(404).json({ error: 'Estrutura não encontrada' });
+  }
+  return res.json(estrutura);
+}

--- a/backend/src/controllers/produto.controller.ts
+++ b/backend/src/controllers/produto.controller.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express';
+import { ProdutoService } from '../services/produto.service';
+
+const produtoService = new ProdutoService();
+
+export function listarProdutos(req: Request, res: Response) {
+  return res.json(produtoService.listar());
+}
+
+export function criarProduto(req: Request, res: Response) {
+  try {
+    const { codigo, ncmCodigo, valoresAtributos } = req.body;
+    if (!codigo || !ncmCodigo) {
+      return res.status(400).json({ error: 'Código e NCM são obrigatórios' });
+    }
+    const produto = produtoService.criar({
+      codigo,
+      ncmCodigo,
+      valoresAtributos: valoresAtributos || {}
+    });
+    return res.status(201).json(produto);
+  } catch (error: any) {
+    return res.status(400).json({ error: error.message });
+  }
+}

--- a/backend/src/data/estruturas-ncm.ts
+++ b/backend/src/data/estruturas-ncm.ts
@@ -1,0 +1,80 @@
+export interface Dominio {
+  codigo: string;
+  descricao: string;
+}
+
+export type FormaPreenchimento =
+  | 'LISTA_ESTATICA'
+  | 'BOOLEANO'
+  | 'TEXTO'
+  | 'NUMERO_REAL'
+  | 'NUMERO_INTEIRO';
+
+export interface Atributo {
+  codigo: string;
+  nome: string;
+  formaPreenchimento: FormaPreenchimento;
+  obrigatorio?: boolean;
+  dominio?: Dominio[];
+}
+
+export interface EstruturaNcm {
+  ncm: string;
+  atributos: Atributo[];
+}
+
+export const estruturasNcm: EstruturaNcm[] = [
+  {
+    ncm: '85171231',
+    atributos: [
+      {
+        codigo: 'sistema_operacional',
+        nome: 'Sistema Operacional',
+        formaPreenchimento: 'LISTA_ESTATICA',
+        obrigatorio: true,
+        dominio: [
+          { codigo: 'ANDROID', descricao: 'Android' },
+          { codigo: 'IOS', descricao: 'iOS' },
+          { codigo: 'OUTRO', descricao: 'Outro' }
+        ]
+      },
+      {
+        codigo: 'memoria_interna_gb',
+        nome: 'Memoria Interna (GB)',
+        formaPreenchimento: 'NUMERO_INTEIRO',
+        obrigatorio: true
+      },
+      {
+        codigo: 'suporta_5g',
+        nome: 'Suporta 5G',
+        formaPreenchimento: 'BOOLEANO'
+      }
+    ]
+  },
+  {
+    ncm: '38089419',
+    atributos: [
+      {
+        codigo: 'registro_anvisa',
+        nome: 'Registro ANVISA',
+        formaPreenchimento: 'TEXTO',
+        obrigatorio: true
+      },
+      {
+        codigo: 'ingrediente_ativo',
+        nome: 'Ingrediente Ativo',
+        formaPreenchimento: 'LISTA_ESTATICA',
+        obrigatorio: true,
+        dominio: [
+          { codigo: 'I1', descricao: 'Ingrediente 1' },
+          { codigo: 'I2', descricao: 'Ingrediente 2' }
+        ]
+      },
+      {
+        codigo: 'concentracao_percentual',
+        nome: 'Concentracao %',
+        formaPreenchimento: 'NUMERO_REAL'
+      }
+    ]
+  }
+];

--- a/backend/src/routes/atributo.routes.ts
+++ b/backend/src/routes/atributo.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { obterEstruturaPorNcm } from '../controllers/atributo.controller';
+import { authMiddleware } from '../middlewares/auth.middleware';
+
+const router = Router();
+router.use(authMiddleware);
+router.get('/ncm/:ncm', obterEstruturaPorNcm);
+export default router;

--- a/backend/src/routes/produto.routes.ts
+++ b/backend/src/routes/produto.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { listarProdutos, criarProduto } from '../controllers/produto.controller';
+import { authMiddleware } from '../middlewares/auth.middleware';
+
+const router = Router();
+router.use(authMiddleware);
+router.get('/', listarProdutos);
+router.post('/', criarProduto);
+export default router;

--- a/backend/src/services/estrutura.service.ts
+++ b/backend/src/services/estrutura.service.ts
@@ -1,0 +1,7 @@
+import { EstruturaNcm, estruturasNcm } from '../data/estruturas-ncm';
+
+export class EstruturaService {
+  obterPorNcm(ncm: string): EstruturaNcm | null {
+    return estruturasNcm.find(e => e.ncm === ncm) || null;
+  }
+}

--- a/backend/src/services/produto.service.ts
+++ b/backend/src/services/produto.service.ts
@@ -1,0 +1,44 @@
+import { EstruturaService } from './estrutura.service';
+import { EstruturaNcm } from '../data/estruturas-ncm';
+
+export interface Produto {
+  id: number;
+  codigo: string;
+  ncmCodigo: string;
+  valoresAtributos: Record<string, any>;
+  estruturaSnapshot: EstruturaNcm;
+}
+
+interface CriarProdutoDTO {
+  codigo: string;
+  ncmCodigo: string;
+  valoresAtributos: Record<string, any>;
+}
+
+export class ProdutoService {
+  private produtos: Produto[] = [];
+  private seq = 1;
+  private estruturaService = new EstruturaService();
+
+  listar(): Produto[] {
+    return this.produtos;
+  }
+
+  criar(data: CriarProdutoDTO): Produto {
+    const estrutura = this.estruturaService.obterPorNcm(data.ncmCodigo);
+    if (!estrutura) {
+      throw new Error('Estrutura não encontrada para o NCM informado');
+    }
+
+    const produto: Produto = {
+      id: this.seq++,
+      codigo: data.codigo,
+      ncmCodigo: data.ncmCodigo,
+      valoresAtributos: data.valoresAtributos,
+      estruturaSnapshot: estrutura
+    };
+
+    this.produtos.push(produto);
+    return produto;
+  }
+}

--- a/frontend/components/produtos/ProdutoForm.tsx
+++ b/frontend/components/produtos/ProdutoForm.tsx
@@ -1,0 +1,155 @@
+import React, { useState } from 'react';
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
+import { CustomSelect } from '@/components/ui/CustomSelect';
+import api from '@/lib/api';
+
+interface Dominio {
+  codigo: string;
+  descricao: string;
+}
+
+interface Atributo {
+  codigo: string;
+  nome: string;
+  formaPreenchimento: 'LISTA_ESTATICA' | 'BOOLEANO' | 'TEXTO' | 'NUMERO_REAL' | 'NUMERO_INTEIRO';
+  obrigatorio?: boolean;
+  dominio?: Dominio[];
+}
+
+interface EstruturaNcm {
+  ncm: string;
+  atributos: Atributo[];
+}
+
+interface Props {
+  onSuccess?: () => void;
+}
+
+export default function ProdutoForm({ onSuccess }: Props) {
+  const [codigo, setCodigo] = useState('');
+  const [ncm, setNcm] = useState('');
+  const [estrutura, setEstrutura] = useState<EstruturaNcm | null>(null);
+  const [valores, setValores] = useState<Record<string, any>>({});
+  const [loadingEstrutura, setLoadingEstrutura] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function buscarEstrutura() {
+    if (ncm.length < 8) return;
+    setLoadingEstrutura(true);
+    try {
+      const resp = await api.get(`/estruturas/ncm/${ncm}`);
+      setEstrutura(resp.data);
+      setValores({});
+    } catch (err) {
+      console.error(err);
+      alert('Estrutura não encontrada');
+    } finally {
+      setLoadingEstrutura(false);
+    }
+  }
+
+  function handleValor(cod: string, valor: any) {
+    setValores(prev => ({ ...prev, [cod]: valor }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      setSubmitting(true);
+      await api.post('/produtos', {
+        codigo,
+        ncmCodigo: ncm,
+        valoresAtributos: valores
+      });
+      alert('Produto criado');
+      onSuccess?.();
+    } catch (err) {
+      console.error(err);
+      alert('Erro ao salvar');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const renderCampo = (atr: Atributo) => {
+    const valor = valores[atr.codigo] ?? '';
+    switch (atr.formaPreenchimento) {
+      case 'TEXTO':
+        return (
+          <Input
+            key={atr.codigo}
+            label={atr.nome}
+            value={valor}
+            onChange={e => handleValor(atr.codigo, e.target.value)}
+          />
+        );
+      case 'NUMERO_INTEIRO':
+        return (
+          <Input
+            key={atr.codigo}
+            label={atr.nome}
+            type="number"
+            value={valor}
+            onChange={e => handleValor(atr.codigo, e.target.value)}
+          />
+        );
+      case 'NUMERO_REAL':
+        return (
+          <Input
+            key={atr.codigo}
+            label={atr.nome}
+            type="number"
+            step="0.01"
+            value={valor}
+            onChange={e => handleValor(atr.codigo, e.target.value)}
+          />
+        );
+      case 'BOOLEANO':
+        return (
+          <div key={atr.codigo} className="mb-4">
+            <label className="flex items-center space-x-2 text-gray-300">
+              <input
+                type="checkbox"
+                checked={valor}
+                onChange={e => handleValor(atr.codigo, e.target.checked)}
+              />
+              <span>{atr.nome}</span>
+            </label>
+          </div>
+        );
+      case 'LISTA_ESTATICA':
+        return (
+          <CustomSelect
+            key={atr.codigo}
+            label={atr.nome}
+            options={atr.dominio?.map(d => ({ value: d.codigo, label: d.descricao })) || []}
+            value={valor}
+            onChange={v => handleValor(atr.codigo, v)}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Input label="Código" value={codigo} onChange={e => setCodigo(e.target.value)} />
+      <div className="flex space-x-2 items-end">
+        <Input
+          label="NCM"
+          value={ncm}
+          onChange={e => setNcm(e.target.value)}
+        />
+        <Button type="button" onClick={buscarEstrutura} disabled={loadingEstrutura}>
+          Carregar
+        </Button>
+      </div>
+      {estrutura && estrutura.atributos.map(renderCampo)}
+      <Button type="submit" disabled={submitting}>
+        Salvar
+      </Button>
+    </form>
+  );
+}

--- a/frontend/pages/produtos.tsx
+++ b/frontend/pages/produtos.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Card } from '@/components/ui/Card';
 import { Search, Plus } from 'lucide-react';
+import Link from 'next/link';
 
 export default function ProdutosPage() {
   return (
@@ -31,12 +32,13 @@ export default function ProdutosPage() {
           <h3 className="text-xl font-medium text-white mb-2">Nenhum produto encontrado</h3>
           <p className="text-gray-400 mb-8">Adicione seus primeiros produtos ao catálogo</p>
           
-          <button 
+          <Link
+            href="/produtos/novo"
             className="flex items-center space-x-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors"
           >
             <Plus size={18} />
             <span>Adicionar Produto</span>
-          </button>
+          </Link>
         </div>
       </div>
     </DashboardLayout>

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+import { Card } from '@/components/ui/Card';
+import ProdutoForm from '@/components/produtos/ProdutoForm';
+
+export default function NovoProdutoPage() {
+  return (
+    <DashboardLayout title="Novo Produto">
+      <Card>
+        <ProdutoForm />
+      </Card>
+    </DashboardLayout>
+  );
+}


### PR DESCRIPTION
## Resumo
- cria estrutura de atributos por NCM no backend
- adiciona serviços e rotas para produtos e estruturas
- adiciona formulário de produto com campos dinâmicos no frontend
- página para novo produto e link na listagem

## Testes
- `npm run build:all` *(falhou: `prisma` não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_685b0073c8608330ba6ce72dffe5940b