### PR TITLE
Corrige exibicao de atributos condicionados

### DIFF
--- a/backend/src/services/produto.service.ts
+++ b/backend/src/services/produto.service.ts
@@ -125,8 +125,10 @@ export class ProdutoService {
 
   private condicaoAtendida(attr: AtributoEstruturaDTO, valores: Record<string, any>): boolean {
     if (!attr.parentCodigo) return true;
-    const atual = String(valores[attr.parentCodigo] ?? '');
-    if (attr.condicao) return this.avaliarExpressao(attr.condicao, atual);
+    const atual = valores[attr.parentCodigo];
+    if (atual === undefined || atual === '') return false;
+    const atualStr = String(atual);
+    if (attr.condicao) return this.avaliarExpressao(attr.condicao, atualStr);
     if (!attr.descricaoCondicao) return true;
     const match = attr.descricaoCondicao.match(/valor\s*=\s*'?"?(\w+)"?'?/i);
     if (!match) return true;

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -71,10 +71,11 @@ export default function NovoProdutoPage() {
 
   function condicaoAtendida(attr: AtributoEstrutura): boolean {
     if (!attr.parentCodigo) return true;
-    const atual = valores[attr.parentCodigo] || '';
+    const atual = valores[attr.parentCodigo];
+    if (atual === undefined || atual === '') return false;
 
     if (attr.condicao) {
-      return avaliarExpressao(attr.condicao, atual);
+      return avaliarExpressao(attr.condicao, String(atual));
     }
 
     if (!attr.descricaoCondicao) return true;


### PR DESCRIPTION
## Descricao
- condicionais avaliadas somente quando ha valor informado

## Testes realizados
- `npm test -- --passWithNoTests` *(falha: DATABASE_URL nao definido)*
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_686bf8156b0083309392159fc0604bc8