### PR TITLE
Corrige visibilidade dinâmica dos atributos

### DIFF
--- a/backend/src/services/produto.service.ts
+++ b/backend/src/services/produto.service.ts
@@ -123,8 +123,16 @@ export class ProdutoService {
     return ok;
   }
 
-  private condicaoAtendida(attr: AtributoEstruturaDTO, valores: Record<string, any>): boolean {
+  private condicaoAtendida(
+    attr: AtributoEstruturaDTO,
+    valores: Record<string, any>,
+    mapa: Map<string, AtributoEstruturaDTO>
+  ): boolean {
     if (!attr.parentCodigo) return true;
+
+    const pai = mapa.get(attr.parentCodigo);
+    if (pai && !this.condicaoAtendida(pai, valores, mapa)) return false;
+
     const atual = valores[attr.parentCodigo];
     if (atual === undefined || atual === '') return false;
     const atualStr = String(atual);
@@ -147,8 +155,11 @@ export class ProdutoService {
     }
     coletar(estrutura);
 
+    const mapa = new Map<string, AtributoEstruturaDTO>();
+    for (const a of todos) mapa.set(a.codigo, a);
+
     for (const attr of todos) {
-      if (!this.condicaoAtendida(attr, valores)) continue;
+      if (!this.condicaoAtendida(attr, valores, mapa)) continue;
       const v = valores[attr.codigo];
       if (attr.obrigatorio && (v === undefined || v === '')) {
         erros[attr.codigo] = 'Obrigatório';

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -26,6 +26,18 @@ export default function NovoProdutoPage() {
   const [estrutura, setEstrutura] = useState<AtributoEstrutura[]>([]);
   const [valores, setValores] = useState<Record<string, string>>({});
 
+  const mapaEstrutura = React.useMemo(() => {
+    const map = new Map<string, AtributoEstrutura>();
+    function coletar(lista: AtributoEstrutura[]) {
+      for (const a of lista) {
+        map.set(a.codigo, a);
+        if (a.subAtributos) coletar(a.subAtributos);
+      }
+    }
+    coletar(estrutura);
+    return map;
+  }, [estrutura]);
+
   function ordenarAtributos(lista: AtributoEstrutura[]): AtributoEstrutura[] {
     const map = new Map(lista.map(a => [a.codigo, a]));
     const resultado: AtributoEstrutura[] = [];
@@ -104,6 +116,10 @@ export default function NovoProdutoPage() {
   // pois o componente re-renderiza sempre que 'valores' é atualizado.
   function condicaoAtendida(attr: AtributoEstrutura): boolean {
     if (!attr.parentCodigo) return true;
+
+    const pai = mapaEstrutura.get(attr.parentCodigo);
+    if (pai && !condicaoAtendida(pai)) return false;
+
     const atual = valores[attr.parentCodigo];
     if (atual === undefined || atual === '') return false;
 


### PR DESCRIPTION
## Resumo
- atualiza página de cadastro para reavaliar a visibilidade de campos condicionados recursivamente
- ajusta serviço de produtos no backend para a mesma lógica

## Testes
- `npm test -- --passWithNoTests` *(falhou: Missing script)*
- `npm run build:all`

------
https://chatgpt.com/codex/tasks/task_e_686c031491e883309f28610692685b2f