### PR TITLE
Corrige parse de JSON com aspas simples

### DIFF
--- a/backend/src/utils/parse-json.ts
+++ b/backend/src/utils/parse-json.ts
@@ -3,8 +3,15 @@ import { logger } from './logger'
 export function parseJsonSafe(text: string): any | undefined {
   try {
     return JSON.parse(text)
-  } catch (error) {
-    logger.error('Erro ao analisar JSON:', error)
-    return undefined
+  } catch (_) {
+    try {
+      const normalized = text
+        .replace(/\b'([^']*)'(?=\s*:)/g, '"$1"')
+        .replace(/:\s*'([^']*)'/g, ': "$1"')
+      return JSON.parse(normalized)
+    } catch (error) {
+      logger.error('Erro ao analisar JSON:', error)
+      return undefined
+    }
   }
 }


### PR DESCRIPTION
## Resumo
- trata strings de condição com aspas simples em `parseJsonSafe`

## Testes
- `npm test -- --passWithNoTests` *(falha: missing script)*
- `npm run build:all` *(falha: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c1b44b55883308521bc533f136e6a