### PR TITLE
Corrige parseJsonSafe

### DIFF
--- a/backend/src/utils/parse-json.ts
+++ b/backend/src/utils/parse-json.ts
@@ -6,7 +6,7 @@ export function parseJsonSafe(text: string): any | undefined {
   } catch (_) {
     try {
       const normalized = text
-        .replace(/\b'([^']*)'(?=\s*:)/g, '"$1"')
+        .replace(/'([^']*)'(?=\s*:)/g, '"$1"')
         .replace(/:\s*'([^']*)'/g, ': "$1"')
       return JSON.parse(normalized)
     } catch (error) {


### PR DESCRIPTION
## Resumo
- remove token \b da regex para tratar chaves com aspas simples

## Testes
- `npm test` *(falhou: comando não encontrado)*
- `npm run build:all` *(falhou: comando não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686c1d6c613c8330bab34ce6fc5af7f3