### PR TITLE
Ajuste de dropdown e boolean no cadastro

### DIFF
--- a/frontend/components/ui/RadioGroup.tsx
+++ b/frontend/components/ui/RadioGroup.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface RadioGroupProps {
+  label?: string;
+  options: Option[];
+  value?: string;
+  onChange?: (value: string) => void;
+  required?: boolean;
+  name?: string;
+  className?: string;
+  error?: string;
+}
+
+export function RadioGroup({
+  label,
+  options,
+  value = '',
+  onChange,
+  required = false,
+  name,
+  className = '',
+  error
+}: RadioGroupProps) {
+  return (
+    <div className={`mb-4 ${className}`}>
+      {label && (
+        <label className="block text-sm font-medium mb-1 text-gray-300">
+          {label}
+          {required && <span className="text-red-400 ml-1">*</span>}
+        </label>
+      )}
+      <div className="flex items-center gap-4">
+        {options.map(opt => (
+          <label key={opt.value} className="inline-flex items-center gap-2">
+            <input
+              type="radio"
+              name={name}
+              value={opt.value}
+              checked={value === opt.value}
+              onChange={() => onChange?.(opt.value)}
+              className="form-radio text-accent bg-[#1e2126] border-gray-700 focus:ring focus:border-blue-500"
+            />
+            <span>{opt.label}</span>
+          </label>
+        ))}
+      </div>
+      {error && <p className="mt-1 text-sm text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/components/ui/Select.tsx
+++ b/frontend/components/ui/Select.tsx
@@ -5,9 +5,10 @@ interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
   label?: string;
   options: Array<{ value: string; label: string }>;
   error?: string;
+  placeholder?: string;
 }
 
-export function Select({ label, options, className = '', error, ...props }: SelectProps) {
+export function Select({ label, options, className = '', error, placeholder = 'Selecione...', ...props }: SelectProps) {
   return (
     <div className={`mb-4 ${className}`}>
       {label && (
@@ -28,6 +29,9 @@ export function Select({ label, options, className = '', error, ...props }: Sele
           backgroundSize: '1.5em 1.5em'
         }}
       >
+        <option value="" hidden>
+          {placeholder}
+        </option>
         {options.map((option) => (
           <option key={option.value} value={option.value}>
             {option.label}
@@ -40,5 +44,4 @@ export function Select({ label, options, className = '', error, ...props }: Sele
         </p>
       )}
     </div>
-  );
-}
+  );}

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -4,6 +4,7 @@ import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Card } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Select } from '@/components/ui/Select';
+import { RadioGroup } from '@/components/ui/RadioGroup';
 import { Button } from '@/components/ui/Button';
 import api from '@/lib/api';
 
@@ -151,13 +152,14 @@ export default function NovoProdutoPage() {
               attr.dominio?.map(d => ({ value: d.codigo, label: d.descricao })) ||
               []
             }
+            placeholder="Selecione..."
             value={value}
             onChange={e => handleValor(attr.codigo, e.target.value)}
           />
         );
       case 'BOOLEANO':
         return (
-          <Select
+          <RadioGroup
             key={attr.codigo}
             label={attr.nome}
             required={attr.obrigatorio}
@@ -166,7 +168,7 @@ export default function NovoProdutoPage() {
               { value: 'false', label: 'Não' }
             ]}
             value={value}
-            onChange={e => handleValor(attr.codigo, e.target.value)}
+            onChange={v => handleValor(attr.codigo, v)}
           />
         );
       case 'NUMERO_INTEIRO':


### PR DESCRIPTION
## Resumo
- incluído componente `RadioGroup`
- `Select` agora possui placeholder "Selecione..."
- página de novo produto utiliza `RadioGroup` para campos booleanos e ajusta dropdowns

## Testes
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_686dde29b1848330a8c18ffb9e0e6c85