### PR TITLE
Ajusta layout de campos dinâmicos

### DIFF
--- a/frontend/components/ui/Input.tsx
+++ b/frontend/components/ui/Input.tsx
@@ -16,7 +16,7 @@ export function Input({ label, error, className = '', ...props }: InputProps) {
       )}
       <input
         id={props.id}
-        className="w-full px-2 py-1.5 bg-[#1e2126] border border-gray-700 text-white rounded-md focus:outline-none focus:ring focus:border-blue-500"
+        className="w-full px-2 py-1 text-sm bg-[#1e2126] border border-gray-700 text-white rounded-md focus:outline-none focus:ring focus:border-blue-500"
         {...props}
       />
       {error && (
@@ -25,5 +25,4 @@ export function Input({ label, error, className = '', ...props }: InputProps) {
         </p>
       )}
     </div>
-  );
-}
+  );}

--- a/frontend/components/ui/RadioGroup.tsx
+++ b/frontend/components/ui/RadioGroup.tsx
@@ -34,7 +34,7 @@ export function RadioGroup({
           {required && <span className="text-red-400 ml-1">*</span>}
         </label>
       )}
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-4 text-sm">
         {options.map(opt => (
           <label key={opt.value} className="inline-flex items-center gap-2">
             <input

--- a/frontend/components/ui/Select.tsx
+++ b/frontend/components/ui/Select.tsx
@@ -19,7 +19,7 @@ export function Select({ label, options, className = '', error, placeholder = 'S
       )}
       <select
         {...props}
-        className={`w-full px-2 py-1.5 bg-[#1e2126] border rounded-md focus:outline-none focus:ring focus:border-blue-500 text-white appearance-none ${
+        className={`w-full px-2 py-1 text-sm bg-[#1e2126] border rounded-md focus:outline-none focus:ring focus:border-blue-500 text-white appearance-none ${
           error ? 'border-red-500' : 'border-gray-700'
         }`}
         style={{
@@ -43,5 +43,4 @@ export function Select({ label, options, className = '', error, placeholder = 'S
           {error}
         </p>
       )}
-    </div>
-  );}
+    </div>  );}

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -196,9 +196,9 @@ export default function NovoProdutoPage() {
         );
       case 'COMPOSTO':
         return (
-          <div key={attr.codigo} className="col-span-2">
-            <p className="font-medium mb-2">{attr.nome}</p>
-            <div className="grid grid-cols-2 gap-4 pl-4">
+          <div key={attr.codigo} className="col-span-3">
+            <p className="font-medium mb-2 text-sm">{attr.nome}</p>
+            <div className="grid grid-cols-3 gap-4 pl-4">
               {attr.subAtributos?.map(sa => renderCampo(sa))}
             </div>
           </div>
@@ -229,13 +229,13 @@ export default function NovoProdutoPage() {
   return (
     <DashboardLayout title="Novo Produto">
       <Card>
-        <div className="grid grid-cols-2 gap-4 mb-4">
+        <div className="grid grid-cols-3 gap-4 mb-4">
           <Input label="NCM" value={ncm} onChange={e => setNcm(e.target.value)} />
           <Input label="Modalidade" value={modalidade} onChange={e => setModalidade(e.target.value)} />
           <Button type="button" onClick={carregarEstrutura}>Carregar Estrutura</Button>
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-3 gap-4 text-sm">
           {estrutura.map(attr => renderCampo(attr))}
         </div>
 


### PR DESCRIPTION
## Resumo
- diminui fonte e padding dos componentes `Input`, `Select` e `RadioGroup`
- reorganiza formulário de novo produto para três colunas
- atualiza composição de campos compostos

## Testes
- `npm test -- --passWithNoTests` *(falha: Missing script)*
- `npm run build:all`

------
https://chatgpt.com/codex/tasks/task_e_686de11735c88330933488d68d0578fd