### PR TITLE
Vincula produto ao catálogo

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -40,7 +40,8 @@ model Catalogo {
   ultima_alteracao DateTime       @map("ultima_alteracao") 
   numero           Int            @map("numero")
   status           CatalogoStatus @map("status")
-  
+  produtos         Produto[]
+
   @@map("catalogo")
 }
 
@@ -180,6 +181,8 @@ model Produto {
   status                    ProdutoStatus     @map("status")
   ncmCodigo                 String            @map("ncm_codigo")
   modalidade                String?           @map("modalidade")
+  catalogoId                Int               @map("catalogo_id")
+  catalogo                  Catalogo          @relation(fields: [catalogoId], references: [id])
   criadoEm                  DateTime          @default(now()) @map("criado_em")
   atualizadoEm              DateTime          @updatedAt @map("atualizado_em")
   criadoPor                 String?           @map("criado_por")
@@ -187,6 +190,7 @@ model Produto {
   atributos                 ProdutoAtributos[]
 
   @@index([ncmCodigo], name: "idx_ncm")
+  @@index([catalogoId], name: "idx_catalogo")
   @@unique([codigo, versao], name: "uk_codigo_versao")
   @@map("produto")
 }

--- a/backend/src/controllers/produto.controller.ts
+++ b/backend/src/controllers/produto.controller.ts
@@ -51,6 +51,9 @@ export async function atualizarProduto(req: Request, res: Response) {
     if (error.message?.includes('não encontrado')) {
       return res.status(404).json({ error: error.message });
     }
+    if (error.message?.includes('não pode ser alterado')) {
+      return res.status(400).json({ error: error.message });
+    }
     logger.error('Erro ao atualizar produto:', error);
     res.status(500).json({ error: error.message });
   }

--- a/backend/src/validators/produto.validator.ts
+++ b/backend/src/validators/produto.validator.ts
@@ -5,12 +5,12 @@ export const createProdutoSchema = z.object({
   codigo: z.string().min(1),
   ncmCodigo: z.string().length(8),
   modalidade: z.string().min(1),
+  catalogoId: z.number().int(),
   valoresAtributos: z.record(z.any()).optional(),
   criadoPor: z.string().optional()
 });
 
 export const updateProdutoSchema = z.object({
-  ncmCodigo: z.string().length(8).optional(),
   modalidade: z.string().min(1).optional(),
   status: z.enum(['RASCUNHO', 'ATIVO', 'INATIVO']).optional(),
   valoresAtributos: z.record(z.any()).optional(),

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -25,6 +25,7 @@ interface AtributoEstrutura {
 }
 
 export default function EditarProdutoPage() {
+  const [catalogoNome, setCatalogoNome] = useState('');
   const [ncm, setNcm] = useState('');
   const [modalidade, setModalidade] = useState('IMPORTACAO');
   const [estrutura, setEstrutura] = useState<AtributoEstrutura[]>([]);
@@ -222,6 +223,7 @@ export default function EditarProdutoPage() {
     try {
       const response = await api.get(`/produtos/${produtoId}`);
       const dados = response.data;
+      setCatalogoNome(dados.catalogo?.nome || '');
       setNcm(dados.ncmCodigo);
       setModalidade(dados.modalidade);
       const estr = dados.atributos?.[0]?.estruturaSnapshotJson || [];
@@ -245,7 +247,6 @@ export default function EditarProdutoPage() {
   async function salvar() {
     try {
       await api.put(`/produtos/${id}`, {
-        ncmCodigo: ncm,
         modalidade,
         valoresAtributos: valores
       });
@@ -280,8 +281,9 @@ export default function EditarProdutoPage() {
   return (
     <DashboardLayout title="Editar Produto">
       <Card>
-        <div className="grid grid-cols-3 gap-4 mb-4">
-          <Input label="NCM" value={ncm} onChange={e => setNcm(e.target.value)} />
+        <div className="grid grid-cols-4 gap-4 mb-4">
+          <Input label="Catálogo" value={catalogoNome} disabled />
+          <Input label="NCM" value={ncm} disabled />
           <Input label="Modalidade" value={modalidade} onChange={e => setModalidade(e.target.value)} />
           <Button type="button" onClick={carregarEstrutura}>Carregar Estrutura</Button>
         </div>


### PR DESCRIPTION
## Resumo
- adiciona relação `Catalogo` -> `Produto` no Prisma
- exige `catalogoId` ao criar produtos e remove alteração de NCM
- evita alteração posterior de NCM e catálogo
- exibe campo de seleção de catálogo na criação de produto
- mostra catálogo e NCM como somente leitura na edição

## Testes
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_686ec097b84c8330960da03c25225753