### PR TITLE
Reorganiza formulários de produtos

### DIFF
--- a/frontend/components/ui/Tabs.tsx
+++ b/frontend/components/ui/Tabs.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+
+interface Tab {
+  id: string;
+  label: string;
+  content: React.ReactNode;
+}
+
+interface TabsProps {
+  tabs: Tab[];
+  initialId?: string;
+  className?: string;
+}
+
+export function Tabs({ tabs, initialId, className = '' }: TabsProps) {
+  const [active, setActive] = useState(initialId || tabs[0]?.id);
+  const current = tabs.find(t => t.id === active);
+
+  return (
+    <div className={className}>
+      <div className="border-b border-gray-700 mb-4 flex">
+        {tabs.map(tab => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActive(tab.id)}
+            className={`py-2 px-4 text-sm transition-colors ${
+              active === tab.id
+                ? 'border-b-2 border-accent text-white'
+                : 'text-gray-400 hover:text-white'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div>{current?.content}</div>
+    </div>
+  );
+}

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/Input';
 import { Select } from '@/components/ui/Select';
 import { RadioGroup } from '@/components/ui/RadioGroup';
 import { Button } from '@/components/ui/Button';
+import { Tabs } from '@/components/ui/Tabs';
 import { useToast } from '@/components/ui/ToastContext';
 import { useRouter } from 'next/router';
 import { PageLoader } from '@/components/ui/PageLoader';
@@ -26,6 +27,7 @@ interface AtributoEstrutura {
 
 export default function EditarProdutoPage() {
   const [catalogoNome, setCatalogoNome] = useState('');
+  const [codigo, setCodigo] = useState('');
   const [ncm, setNcm] = useState('');
   const [modalidade, setModalidade] = useState('IMPORTACAO');
   const [estrutura, setEstrutura] = useState<AtributoEstrutura[]>([]);
@@ -223,6 +225,7 @@ export default function EditarProdutoPage() {
     try {
       const response = await api.get(`/produtos/${produtoId}`);
       const dados = response.data;
+      setCodigo(dados.codigo);
       setCatalogoNome(dados.catalogo?.nome || '');
       setNcm(dados.ncmCodigo);
       setModalidade(dados.modalidade);
@@ -280,23 +283,49 @@ export default function EditarProdutoPage() {
 
   return (
     <DashboardLayout title="Editar Produto">
-      <Card>
-        <div className="grid grid-cols-4 gap-4 mb-4">
-          <Input label="Catálogo" value={catalogoNome} disabled />
+      <Card className="mb-6" headerTitle="Seleção do Catálogo">
+        <Input label="Catálogo" value={catalogoNome} disabled />
+      </Card>
+
+      <Card className="mb-6" headerTitle="Dados da NCM">
+        <div className="grid grid-cols-3 gap-4">
           <Input label="NCM" value={ncm} disabled />
           <Input label="Modalidade" value={modalidade} onChange={e => setModalidade(e.target.value)} />
-          <Button type="button" onClick={carregarEstrutura}>Carregar Estrutura</Button>
-        </div>
-
-        <div className="grid grid-cols-3 gap-4 text-sm">
-          {estrutura.map(attr => renderCampo(attr))}
-        </div>
-
-        <div className="mt-4 flex justify-end gap-3">
-          <Button type="button" variant="outline" onClick={() => router.push('/produtos')}>Cancelar</Button>
-          <Button type="button" onClick={salvar}>Salvar Produto</Button>
+          <div className="flex items-end">
+            <Button type="button" onClick={carregarEstrutura}>Carregar Estrutura</Button>
+          </div>
         </div>
       </Card>
+
+      <Card className="mb-6" headerTitle="Dados do Produto">
+        <Tabs
+          tabs={[
+            {
+              id: 'fixos',
+              label: 'Dados Fixos',
+              content: (
+                <div className="grid grid-cols-3 gap-4">
+                  <Input label="Código" value={codigo} disabled />
+                </div>
+              )
+            },
+            {
+              id: 'dinamicos',
+              label: 'Atributos Dinâmicos',
+              content: (
+                <div className="grid grid-cols-3 gap-4 text-sm">
+                  {estrutura.map(attr => renderCampo(attr))}
+                </div>
+              )
+            }
+          ]}
+        />
+      </Card>
+
+      <div className="flex justify-end gap-3">
+        <Button type="button" variant="outline" onClick={() => router.push('/produtos')}>Cancelar</Button>
+        <Button type="button" onClick={salvar}>Salvar Produto</Button>
+      </div>
     </DashboardLayout>
   );
 }

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/Input';
 import { Select } from '@/components/ui/Select';
 import { RadioGroup } from '@/components/ui/RadioGroup';
 import { Button } from '@/components/ui/Button';
+import { Tabs } from '@/components/ui/Tabs';
 import { useToast } from '@/components/ui/ToastContext';
 import { useRouter } from 'next/router';
 import api from '@/lib/api';
@@ -25,6 +26,7 @@ interface AtributoEstrutura {
 
 export default function NovoProdutoPage() {
   const [catalogoId, setCatalogoId] = useState('');
+  const [codigo] = useState(() => `PROD-${Date.now()}`);
   const [catalogos, setCatalogos] = useState<Array<{ id: number; nome: string }>>([]);
   const [ncm, setNcm] = useState('');
   const [modalidade, setModalidade] = useState('IMPORTACAO');
@@ -261,33 +263,55 @@ export default function NovoProdutoPage() {
 
   return (
     <DashboardLayout title="Novo Produto">
-      <Card>
-        <div className="grid grid-cols-3 gap-4 mb-4">
-          <Select
-            label="Catálogo"
-            options={catalogos.map(c => ({ value: String(c.id), label: c.nome }))}
-            value={catalogoId}
-            onChange={e => setCatalogoId(e.target.value)}
-          />
-          {catalogoId && (
-            <>
+      <Card className="mb-6" headerTitle="Seleção do Catálogo">
+        <Select
+          label="Catálogo"
+          options={catalogos.map(c => ({ value: String(c.id), label: c.nome }))}
+          value={catalogoId}
+          onChange={e => setCatalogoId(e.target.value)}
+        />
+      </Card>
+
+      {catalogoId && (
+        <>
+          <Card className="mb-6" headerTitle="Dados da NCM">
+            <div className="grid grid-cols-3 gap-4">
               <Input label="NCM" value={ncm} onChange={e => setNcm(e.target.value)} />
               <Input label="Modalidade" value={modalidade} onChange={e => setModalidade(e.target.value)} />
-              <Button type="button" onClick={carregarEstrutura}>Carregar Estrutura</Button>
-            </>
-          )}
-        </div>
-
-        {catalogoId && (
-          <>
-            <div className="grid grid-cols-3 gap-4 text-sm">
-              {estrutura.map(attr => renderCampo(attr))}
+              <div className="flex items-end">
+                <Button type="button" onClick={carregarEstrutura}>Carregar Estrutura</Button>
+              </div>
             </div>
+          </Card>
 
-            <Button type="button" onClick={salvar} className="mt-4">Salvar Produto</Button>
-          </>
-        )}
-      </Card>
+          <Card className="mb-6" headerTitle="Dados do Produto">
+            <Tabs
+              tabs={[
+                {
+                  id: 'fixos',
+                  label: 'Dados Fixos',
+                  content: (
+                    <div className="grid grid-cols-3 gap-4">
+                      <Input label="Código" value={codigo} disabled />
+                    </div>
+                  )
+                },
+                {
+                  id: 'dinamicos',
+                  label: 'Atributos Dinâmicos',
+                  content: (
+                    <div className="grid grid-cols-3 gap-4 text-sm">
+                      {estrutura.map(attr => renderCampo(attr))}
+                    </div>
+                  )
+                }
+              ]}
+            />
+          </Card>
+
+          <Button type="button" onClick={salvar}>Salvar Produto</Button>
+        </>
+      )}
     </DashboardLayout>
   );
 }


### PR DESCRIPTION
## Resumo
- cria componente simples de abas
- organiza o cadastro e edição de produtos em seções
- adiciona abas para dados fixos e atributos dinâmicos

## Testes
- `npm run build:all`

------
https://chatgpt.com/codex/tasks/task_e_686ed99a853883309debbea0ef4f80ca