### PR TITLE
Ajuste no layout do cadastro de produtos

### DIFF
--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -284,11 +284,8 @@ export default function EditarProdutoPage() {
   return (
     <DashboardLayout title="Editar Produto">
       <Card className="mb-6" headerTitle="Seleção do Catálogo">
-        <Input label="Catálogo" value={catalogoNome} disabled />
-      </Card>
-
-      <Card className="mb-6" headerTitle="Dados da NCM">
         <div className="grid grid-cols-3 gap-4">
+          <Input label="Catálogo" value={catalogoNome} disabled />
           <Input label="NCM" value={ncm} disabled />
           <Input label="Modalidade" value={modalidade} onChange={e => setModalidade(e.target.value)} />
           <div className="flex items-end">

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -277,25 +277,27 @@ export default function NovoProdutoPage() {
   return (
     <DashboardLayout title="Novo Produto">
       <Card className="mb-6" headerTitle="Seleção do Catálogo">
-        <Select
-          label="Catálogo"
-          options={catalogos.map(c => ({ value: String(c.id), label: c.nome }))}
-          value={catalogoId}
-          onChange={e => setCatalogoId(e.target.value)}
-        />
-      </Card>
-
-      {catalogoId && (
-        <>
-          <Card className="mb-6" headerTitle="Dados da NCM">
-            <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-3 gap-4">
+          <Select
+            label="Catálogo"
+            options={catalogos.map(c => ({ value: String(c.id), label: c.nome }))}
+            value={catalogoId}
+            onChange={e => setCatalogoId(e.target.value)}
+          />
+          {catalogoId && (
+            <>
               <Input label="NCM" value={ncm} onChange={e => setNcm(e.target.value)} />
               <Input label="Modalidade" value={modalidade} onChange={e => setModalidade(e.target.value)} />
               <div className="flex items-end">
                 <Button type="button" onClick={carregarEstrutura}>Carregar Estrutura</Button>
               </div>
-            </div>
-          </Card>
+            </>
+          )}
+        </div>
+      </Card>
+
+      {catalogoId && (
+        <>
 
           {loadingEstrutura && (
             <Card className="mb-6">


### PR DESCRIPTION
## Descrição
- Campos de NCM e modalidade foram movidos para o card de seleção do catálogo
- Mantida a lógica condicional para exibir informações somente após escolher o catálogo
- Build executado com sucesso, mas testes falharam por ausência do script `test`


------
https://chatgpt.com/codex/tasks/task_e_686ee00f88648330874796a853d5db3c