### PR TITLE
Adiciona CPF/CNPJ na lista de produtos

### DIFF
--- a/backend/src/services/produto.service.ts
+++ b/backend/src/services/produto.service.ts
@@ -31,7 +31,8 @@ export class ProdutoService {
     return produtos.map(p => ({
       ...p,
       catalogoNumero: p.catalogo?.numero,
-      catalogoNome: p.catalogo?.nome
+      catalogoNome: p.catalogo?.nome,
+      catalogoCpfCnpj: p.catalogo?.cpf_cnpj
     }));
   }
 

--- a/frontend/pages/produtos.tsx
+++ b/frontend/pages/produtos.tsx
@@ -19,6 +19,7 @@ interface Produto {
   atualizadoEm: string;
   catalogoNumero?: number;
   catalogoNome?: string;
+  catalogoCpfCnpj?: string;
   nome?: string;
   codigoInterno?: string;
   situacao?: string;
@@ -147,6 +148,7 @@ export default function ProdutosPage() {
                   <th className="w-16 px-4 py-3 text-center">Ações</th>
                   <th className="px-4 py-3">Nº do Catálogo</th>
                   <th className="px-4 py-3">Nome Catálogo</th>
+                  <th className="px-4 py-3">CPF/CNPJ</th>
                   <th className="px-4 py-3">Nome do Produto</th>
                   <th className="px-4 py-3">Código Interno</th>
                   <th className="px-4 py-3">NCM</th>
@@ -172,6 +174,7 @@ export default function ProdutosPage() {
                     </td>
                     <td className="px-4 py-3 font-mono text-[#f59e0b]">{produto.catalogoNumero ?? '-'}</td>
                     <td className="px-4 py-3">{produto.catalogoNome ?? '-'}</td>
+                    <td className="px-4 py-3">{produto.catalogoCpfCnpj ?? '-'}</td>
                     <td className="px-4 py-3">{produto.nome ?? produto.codigo}</td>
                     <td className="px-4 py-3">{produto.codigoInterno ?? '-'}</td>
                     <td className="px-4 py-3 font-mono">{produto.ncmCodigo}</td>


### PR DESCRIPTION
## Resumo
- exibir CPF/CNPJ do catálogo na tela de produtos
- ajustar serviço do backend para retornar o campo

## Testes
- `npm test -- --passWithNoTests` *(falhou: DATABASE_URL não definida)*
- `npm run build:all`

------
https://chatgpt.com/codex/tasks/task_e_686ff87ee944833082d0750b0abb7338