### PR TITLE
Inclui máscara de NCM com carregamento automático

### DIFF
--- a/frontend/components/ui/MaskedInput.tsx
+++ b/frontend/components/ui/MaskedInput.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react';
 interface MaskedInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   label?: string;
   error?: string;
-  mask: 'cpf' | 'cnpj' | 'cpf-cnpj' | 'cep';
+  mask: 'cpf' | 'cnpj' | 'cpf-cnpj' | 'cep' | 'ncm';
   value: string | undefined;
   onChange: (value: string, formattedValue: string) => void;
 }
@@ -57,6 +57,19 @@ function applyCEPMask(value: string): string {
 }
 
 /**
+ * Aplica máscara de NCM
+ */
+function applyNCMMask(value: string): string {
+  const numbers = onlyNumbers(value).slice(0, 8);
+  return numbers.replace(/(\d{4})(\d{0,2})(\d{0,2})/, (_, p1, p2, p3) => {
+    let result = p1;
+    if (p2) result += `.${p2}`;
+    if (p3) result += `.${p3}`;
+    return result;
+  });
+}
+
+/**
  * Aplica máscara dinâmica para CPF ou CNPJ
  */
 function applyCPFOrCNPJMask(value: string): string {
@@ -85,6 +98,8 @@ function applyMask(value: string, mask: MaskedInputProps['mask']): string {
       return applyCPFOrCNPJMask(value);
     case 'cep':
       return applyCEPMask(value);
+    case 'ncm':
+      return applyNCMMask(value);
     default:
       return value;
   }
@@ -103,6 +118,8 @@ function getPlaceholder(mask: MaskedInputProps['mask']): string {
       return 'CPF: 000.000.000-00 ou CNPJ: 00.000.000/0000-00';
     case 'cep':
       return '00000-000';
+    case 'ncm':
+      return '9999.99.99';
     default:
       return '';
   }
@@ -121,6 +138,8 @@ function getMaxLength(mask: MaskedInputProps['mask']): number | undefined {
       return 18; // Maior entre CPF e CNPJ
     case 'cep':
       return 9;  // 00000-000
+    case 'ncm':
+      return 10; // 9999.99.99
     default:
       return undefined;
   }

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Card } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
+import { MaskedInput } from '@/components/ui/MaskedInput';
 import { Select } from '@/components/ui/Select';
 import { RadioGroup } from '@/components/ui/RadioGroup';
 import { Button } from '@/components/ui/Button';
@@ -97,12 +98,12 @@ export default function NovoProdutoPage() {
     return resultado;
   }
 
-  async function carregarEstrutura() {
-    if (ncm.length < 8) return;
+  async function carregarEstrutura(ncmCodigo: string = ncm) {
+    if (ncmCodigo.length < 8) return;
     setLoadingEstrutura(true);
     try {
       const response = await api.get(
-        `/siscomex/atributos/ncm/${ncm}?modalidade=${modalidade}`
+        `/siscomex/atributos/ncm/${ncmCodigo}?modalidade=${modalidade}`
       );
       const dados: AtributoEstrutura[] = response.data.dados || [];
       setNcmDescricao(response.data.descricaoNcm || '');
@@ -114,6 +115,13 @@ export default function NovoProdutoPage() {
       setEstruturaCarregada(false);
     } finally {
       setLoadingEstrutura(false);
+    }
+  }
+
+  function handleNcmChange(value: string) {
+    setNcm(value);
+    if (value.length === 8) {
+      carregarEstrutura(value);
     }
   }
 
@@ -296,7 +304,12 @@ export default function NovoProdutoPage() {
           />
           {catalogoId && (
             <>
-              <Input label="NCM" value={ncm} onChange={e => setNcm(e.target.value)} />
+              <MaskedInput
+                label="NCM"
+                mask="ncm"
+                value={ncm}
+                onChange={(value) => handleNcmChange(value)}
+              />
               <Select
                 label="Modalidade"
                 options={[
@@ -306,9 +319,6 @@ export default function NovoProdutoPage() {
                 value={modalidade}
                 onChange={e => setModalidade(e.target.value)}
               />
-              <div className="flex items-end">
-                <Button type="button" onClick={carregarEstrutura}>Carregar Estrutura</Button>
-              </div>
             </>
           )}
         </div>


### PR DESCRIPTION
## Resumo
- adiciona nova máscara `ncm` ao componente `MaskedInput`
- aplica `MaskedInput` no cadastro de produto
- remove o botão de carregar estrutura e faz a carga automática ao preencher os 8 dígitos

## Testes
- `npm run build:all`
- `npm build` (falha: Unknown command)

------
https://chatgpt.com/codex/tasks/task_e_687023f9efb48330b23839a49b24ca33