### PR TITLE
Adiciona máscara no campo de NCM

### DIFF
--- a/frontend/components/ui/MaskedInput.tsx
+++ b/frontend/components/ui/MaskedInput.tsx
@@ -1,10 +1,11 @@
 // frontend/components/ui/MaskedInput.tsx (CORRIGIDO)
 import React, { useState, useEffect } from 'react';
 
-interface MaskedInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+interface MaskedInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   label?: string;
   error?: string;
-  mask: 'cpf' | 'cnpj' | 'cpf-cnpj' | 'cep';
+  mask: 'cpf' | 'cnpj' | 'cpf-cnpj' | 'cep' | 'ncm';
   value: string | undefined;
   onChange: (value: string, formattedValue: string) => void;
 }
@@ -56,6 +57,15 @@ function applyCEPMask(value: string): string {
   return value;
 }
 
+function applyNCMMask(value: string): string {
+  const numbers = onlyNumbers(value).slice(0, 8);
+  if (numbers.length <= 4) return numbers;
+  if (numbers.length <= 6) {
+    return numbers.replace(/(\d{4})(\d{1,2})/, '$1.$2');
+  }
+  return numbers.replace(/(\d{4})(\d{2})(\d{1,2})/, '$1.$2.$3');
+}
+
 /**
  * Aplica máscara dinâmica para CPF ou CNPJ
  */
@@ -85,6 +95,8 @@ function applyMask(value: string, mask: MaskedInputProps['mask']): string {
       return applyCPFOrCNPJMask(value);
     case 'cep':
       return applyCEPMask(value);
+    case 'ncm':
+      return applyNCMMask(value);
     default:
       return value;
   }
@@ -103,6 +115,8 @@ function getPlaceholder(mask: MaskedInputProps['mask']): string {
       return 'CPF: 000.000.000-00 ou CNPJ: 00.000.000/0000-00';
     case 'cep':
       return '00000-000';
+    case 'ncm':
+      return '9999.99.99';
     default:
       return '';
   }
@@ -121,6 +135,8 @@ function getMaxLength(mask: MaskedInputProps['mask']): number | undefined {
       return 18; // Maior entre CPF e CNPJ
     case 'cep':
       return 9;  // 00000-000
+    case 'ncm':
+      return 10; // 9999.99.99
     default:
       return undefined;
   }

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Card } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
+import { MaskedInput } from '@/components/ui/MaskedInput';
 import { Select } from '@/components/ui/Select';
 import { RadioGroup } from '@/components/ui/RadioGroup';
 import { Button } from '@/components/ui/Button';
@@ -121,11 +122,10 @@ export default function NovoProdutoPage() {
     }
   }
 
-  function handleNcmChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const value = e.target.value;
-    setNcm(value);
-    if (value.length === 8) {
-      carregarEstrutura(value);
+  function handleNcmChange(valor: string) {
+    setNcm(valor);
+    if (valor.length === 8) {
+      carregarEstrutura(valor);
     } else {
       setNcmDescricao('');
       setUnidadeMedida('');
@@ -329,7 +329,13 @@ export default function NovoProdutoPage() {
 
         {catalogoId && (
           <div className="grid grid-cols-5 gap-4 mt-4">
-            <Input label="NCM" value={ncm} onChange={handleNcmChange} className="col-span-1" />
+            <MaskedInput
+              label="NCM"
+              mask="ncm"
+              value={ncm}
+              onChange={(val) => handleNcmChange(val)}
+              className="col-span-1"
+            />
             <Input label="Descrição" value={ncmDescricao} disabled className="col-span-3" />
             <Input label="Unidade" value={unidadeMedida} disabled className="col-span-1" />
           </div>


### PR DESCRIPTION
## Resumo
- cria máscara `ncm` no componente `MaskedInput`
- aplica a nova máscara no cadastro de produtos e carrega atributos automaticamente

## Testes
- `npm run build:all`
- `cd backend && npm test` *(falha: DATABASE_URL não definida)*

------
https://chatgpt.com/codex/tasks/task_e_68715c1fdc148330b138a3b016e08950