### PR TITLE
ajuste-codigos-produto

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -176,7 +176,7 @@ model AtributosCache {
 // Tabela de produtos
 model Produto {
   id                        Int               @id @default(autoincrement()) @map("id")
-  codigo                    String            @unique @map("codigo")
+  codigo                    String?           @unique @map("codigo")
   versao                    Int               @map("versao")
   status                    ProdutoStatus     @map("status")
   ncmCodigo                 String            @map("ncm_codigo")
@@ -188,6 +188,7 @@ model Produto {
   criadoPor                 String?           @map("criado_por")
   versaoEstruturaAtributos  Int?              @map("versao_estrutura_atributos")
   atributos                 ProdutoAtributos[]
+  codigosInternos           CodigoInternoProduto[]
 
   @@index([ncmCodigo], name: "idx_ncm")
   @@index([catalogoId], name: "idx_catalogo")
@@ -206,4 +207,13 @@ model ProdutoAtributos {
   produto               Produto   @relation(fields: [produtoId], references: [id])
 
   @@map("produto_atributos")
+}
+
+model CodigoInternoProduto {
+  id        Int     @id @default(autoincrement()) @map("id")
+  produtoId Int     @map("produto_id")
+  codigo    String  @map("codigo")
+  produto   Produto @relation(fields: [produtoId], references: [id], onDelete: Cascade)
+
+  @@map("codigo_interno_produto")
 }

--- a/backend/src/validators/produto.validator.ts
+++ b/backend/src/validators/produto.validator.ts
@@ -2,11 +2,12 @@
 import { z } from 'zod';
 
 export const createProdutoSchema = z.object({
-  codigo: z.string().min(1),
+  codigo: z.string().min(1).optional(),
   ncmCodigo: z.string().length(8),
   modalidade: z.string().min(1),
   catalogoId: z.number().int(),
   valoresAtributos: z.record(z.any()).optional(),
+  codigosInternos: z.array(z.string().max(50)).optional(),
   criadoPor: z.string().optional()
 });
 
@@ -14,5 +15,6 @@ export const updateProdutoSchema = z.object({
   modalidade: z.string().min(1).optional(),
   status: z.enum(['RASCUNHO', 'ATIVO', 'INATIVO']).optional(),
   valoresAtributos: z.record(z.any()).optional(),
+  codigosInternos: z.array(z.string().max(50)).optional(),
   atualizadoPor: z.string().optional()
 });

--- a/frontend/pages/produtos.tsx
+++ b/frontend/pages/produtos.tsx
@@ -60,7 +60,7 @@ export default function ProdutosPage() {
   const produtosFiltrados = produtos.filter(p => {
     const termo = busca.toLowerCase();
     return (
-      p.codigo.toLowerCase().includes(termo) ||
+      (p.codigo || '').toLowerCase().includes(termo) ||
       p.ncmCodigo.toLowerCase().includes(termo) ||
       (p.nome && p.nome.toLowerCase().includes(termo))
     );
@@ -175,7 +175,7 @@ export default function ProdutosPage() {
                     <td className="px-4 py-3 font-mono text-[#f59e0b]">{produto.catalogoNumero ?? '-'}</td>
                     <td className="px-4 py-3">{produto.catalogoNome ?? '-'}</td>
                     <td className="px-4 py-3">{produto.catalogoCpfCnpj ?? '-'}</td>
-                    <td className="px-4 py-3">{produto.nome ?? produto.codigo}</td>
+                    <td className="px-4 py-3">{produto.nome ?? produto.codigo ?? '-'}</td>
                     <td className="px-4 py-3">{produto.codigoInterno ?? '-'}</td>
                     <td className="px-4 py-3 font-mono">{produto.ncmCodigo}</td>
                     <td className="px-4 py-3">{produto.status}</td>

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -28,6 +28,8 @@ interface AtributoEstrutura {
 export default function EditarProdutoPage() {
   const [catalogoNome, setCatalogoNome] = useState('');
   const [codigo, setCodigo] = useState('');
+  const [codigosInternos, setCodigosInternos] = useState<string[]>([]);
+  const [novoCodigoInterno, setNovoCodigoInterno] = useState('');
   const [ncm, setNcm] = useState('');
   const [ncmDescricao, setNcmDescricao] = useState('');
   const [modalidade, setModalidade] = useState('IMPORTACAO');
@@ -92,6 +94,12 @@ export default function EditarProdutoPage() {
 
   function handleValor(codigo: string, valor: string) {
     setValores(prev => ({ ...prev, [codigo]: valor }));
+  }
+
+  function adicionarCodigoInterno() {
+    if (!novoCodigoInterno.trim()) return;
+    setCodigosInternos(prev => [...prev, novoCodigoInterno.trim()]);
+    setNovoCodigoInterno('');
   }
 
   function avaliarExpressao(cond: any, valor: string): boolean {
@@ -230,6 +238,7 @@ export default function EditarProdutoPage() {
       const response = await api.get(`/produtos/${produtoId}`);
       const dados = response.data;
       setCodigo(dados.codigo);
+      setCodigosInternos(dados.codigosInternos || []);
       setCatalogoNome(dados.catalogo?.nome || '');
       setNcm(dados.ncmCodigo);
       setModalidade(dados.modalidade);
@@ -263,7 +272,8 @@ export default function EditarProdutoPage() {
     try {
       await api.put(`/produtos/${id}`, {
         modalidade,
-        valoresAtributos: valores
+        valoresAtributos: valores,
+        codigosInternos
       });
       addToast('Produto atualizado com sucesso!', 'success');
       router.push('/produtos');
@@ -321,8 +331,29 @@ export default function EditarProdutoPage() {
               id: 'fixos',
               label: 'Dados Fixos',
               content: (
-                <div className="grid grid-cols-3 gap-4">
-                  <Input label="Código" value={codigo} disabled />
+                <div className="grid grid-cols-3 gap-4 text-sm">
+                  <Input label="Código" value={codigo || '-'} disabled />
+
+                  <div className="col-span-3 mt-2">
+                    <label className="block text-sm font-medium mb-1 text-gray-300">
+                      Código Interno
+                    </label>
+                    <div className="flex gap-2 mb-2">
+                      <Input
+                        value={novoCodigoInterno}
+                        onChange={e => setNovoCodigoInterno(e.target.value)}
+                        className="mb-0 flex-1"
+                      />
+                      <Button type="button" onClick={adicionarCodigoInterno}>+ Incluir</Button>
+                    </div>
+                    {codigosInternos.length > 0 && (
+                      <ul className="list-disc list-inside text-gray-300">
+                        {codigosInternos.map((c, i) => (
+                          <li key={i}>{c}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
                 </div>
               )
             },

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -29,7 +29,9 @@ interface AtributoEstrutura {
 
 export default function NovoProdutoPage() {
   const [catalogoId, setCatalogoId] = useState('');
-  const [codigo] = useState(() => `PROD-${Date.now()}`);
+  const [codigo] = useState('');
+  const [codigosInternos, setCodigosInternos] = useState<string[]>([]);
+  const [novoCodigoInterno, setNovoCodigoInterno] = useState('');
   const [catalogos, setCatalogos] = useState<Array<{ id: number; nome: string; cpf_cnpj: string | null }>>([]);
   const [ncm, setNcm] = useState('');
   const [ncmDescricao, setNcmDescricao] = useState('');
@@ -145,6 +147,12 @@ export default function NovoProdutoPage() {
 
   function handleValor(codigo: string, valor: string) {
     setValores(prev => ({ ...prev, [codigo]: valor }));
+  }
+
+  function adicionarCodigoInterno() {
+    if (!novoCodigoInterno.trim()) return;
+    setCodigosInternos(prev => [...prev, novoCodigoInterno.trim()]);
+    setNovoCodigoInterno('');
   }
 
   function avaliarExpressao(cond: any, valor: string): boolean {
@@ -284,11 +292,11 @@ export default function NovoProdutoPage() {
   async function salvar() {
     try {
       await api.post('/produtos', {
-        codigo: `PROD-${Date.now()}`,
         ncmCodigo: ncm,
         modalidade,
         catalogoId: Number(catalogoId),
-        valoresAtributos: valores
+        valoresAtributos: valores,
+        codigosInternos
       });
       addToast('Produto salvo com sucesso!', 'success');
       router.push('/produtos');
@@ -331,7 +339,7 @@ export default function NovoProdutoPage() {
           />
           {estruturaCarregada && !loadingEstrutura && (
               <div className="grid grid-cols-1 gap-4">
-                <Input label="Código" value={codigo} disabled />
+                <Input label="Código" value={codigo || '-'} disabled />
               </div>
             )}
         </div>
@@ -376,11 +384,32 @@ export default function NovoProdutoPage() {
                             label="Nome do Produto"
                             className="col-span-1"
                           />
-                          
+
                           <Input
                             label="Descrição do Produto"
                             className="col-span-1"
                           />
+
+                          <div className="col-span-3">
+                            <label className="block text-sm font-medium mb-1 text-gray-300">
+                              Código Interno
+                            </label>
+                            <div className="flex gap-2 mb-2">
+                              <Input
+                                value={novoCodigoInterno}
+                                onChange={e => setNovoCodigoInterno(e.target.value)}
+                                className="mb-0 flex-1"
+                              />
+                              <Button type="button" onClick={adicionarCodigoInterno}>+ Incluir</Button>
+                            </div>
+                            {codigosInternos.length > 0 && (
+                              <ul className="list-disc list-inside text-sm text-gray-300">
+                                {codigosInternos.map((c, i) => (
+                                  <li key={i}>{c}</li>
+                                ))}
+                              </ul>
+                            )}
+                          </div>
                         </div>
                       )
                     },

--- a/scripts_banco_catalogo_produtos.sql
+++ b/scripts_banco_catalogo_produtos.sql
@@ -175,7 +175,7 @@ DELIMITER ;
     CREATE TABLE produto (
         id INT PRIMARY KEY AUTO_INCREMENT,
         catalogo_id INT UNSIGNED NOT NULL,
-        codigo VARCHAR(50) UNIQUE NOT NULL,
+        codigo VARCHAR(50) UNIQUE DEFAULT NULL,
         versao INT NOT NULL DEFAULT 1,
         status ENUM('RASCUNHO', 'ATIVO', 'INATIVO') DEFAULT 'RASCUNHO',
         ncm_codigo VARCHAR(8) NOT NULL,
@@ -201,6 +201,13 @@ DELIMITER ;
         validado_em TIMESTAMP NULL,
         erros_validacao JSON NULL,
         FOREIGN KEY (produto_id) REFERENCES produto(id)
+    );
+
+    CREATE TABLE codigo_interno_produto (
+        id INT PRIMARY KEY AUTO_INCREMENT,
+        produto_id INT NOT NULL,
+        codigo VARCHAR(50) NOT NULL,
+        FOREIGN KEY (produto_id) REFERENCES produto(id) ON DELETE CASCADE
     );
 
 


### PR DESCRIPTION
## Resumo
- campo `codigo` de Produto agora é opcional
- adiciona tabela `codigo_interno_produto`
- API aceita lista de códigos internos
- telas de produto exibem hífen quando não há código
- permite cadastrar e listar códigos internos

## Testes
- `npm run build` falhou: comando inexistente
- `npm test -- --passWithNoTests` falhou: comando inexistente

------
https://chatgpt.com/codex/tasks/task_e_68747c8f9918833099d12057378462ad