### PR TITLE
Ajusta seção de códigos internos

### DIFF
--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -396,15 +396,12 @@ export default function NovoProdutoPage() {
                           />
 
                           <div className="col-span-3">
-                            <Card>
-                              <label className="block text-sm font-medium mb-1 text-gray-300">
-                                Código Interno
-                              </label>
+                            <Card headerTitle="Códigos Internos">
                               <div className="flex gap-2 mb-4">
                                 <Input
                                   value={novoCodigoInterno}
                                   onChange={e => setNovoCodigoInterno(e.target.value)}
-                                  className="mb-0 flex-1"
+                                  className="mb-0 w-1/2"
                                 />
                                 <Button type="button" onClick={adicionarCodigoInterno}>+ Incluir</Button>
                               </div>


### PR DESCRIPTION
## Resumo
- adiciona header "Códigos Internos" no card de códigos internos
- reduz largura do campo de código interno para metade

## Testes
- `npm run build:all`
- `npm test` *(falhou: Prisma schema validation - get-config wasm)*


------
https://chatgpt.com/codex/tasks/task_e_6875015adfc48330a1f854c022f33b4a