### PR TITLE
Ajustes visuais e colunas de operadores

### DIFF
--- a/frontend/components/ui/Card.tsx
+++ b/frontend/components/ui/Card.tsx
@@ -13,9 +13,9 @@ export function Card({ children, className = '', headerTitle, headerSubtitle, he
   return (
     <div className={`bg-[#151921] shadow-md rounded-lg overflow-hidden border border-gray-700 ${className}`}>
       {(headerTitle || headerSubtitle) && (
-        <div className={`bg-[#151921] px-6 py-4 border-b border-gray-700 ${headerClassName}`}>
-          {headerTitle && <h2 className="text-lg font-medium text-white">{headerTitle}</h2>}
-          {headerSubtitle && <p className="text-sm text-gray-400">{headerSubtitle}</p>}
+        <div className={`bg-[#151921] px-4 py-2 border-b border-gray-700 ${headerClassName}`}>
+          {headerTitle && <h2 className="text-base font-medium text-white">{headerTitle}</h2>}
+          {headerSubtitle && <p className="text-xs text-gray-400">{headerSubtitle}</p>}
         </div>
       )}
       <div className={!className?.includes('p-0') ? 'p-6' : ''}>

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -13,6 +13,7 @@ import { PageLoader } from '@/components/ui/PageLoader';
 import api from '@/lib/api';
 import { Trash2 } from 'lucide-react';
 import { useOperadorEstrangeiro, OperadorEstrangeiro } from '@/hooks/useOperadorEstrangeiro';
+import { formatCPFOrCNPJ, formatCEP } from '@/lib/validation';
 import { OperadorEstrangeiroSelector } from '@/components/operadores-estrangeriros/OperadorEstrangeiroSelector';
 
 interface AtributoEstrutura {
@@ -122,6 +123,16 @@ export default function EditarProdutoPage() {
 
   function removerOperador(index: number) {
     setOperadores(prev => prev.filter((_, i) => i !== index));
+  }
+
+  function formatarEndereco(op?: OperadorEstrangeiro | null) {
+    if (!op) return '';
+    const partes: string[] = [];
+    if (op.logradouro) partes.push(op.logradouro);
+    if (op.cidade) partes.push(op.cidade);
+    if (op.subdivisao) partes.push(op.subdivisao.nome);
+    const endereco = partes.join(', ');
+    return op.codigoPostal ? `${endereco} - ${formatCEP(op.codigoPostal)}` : endereco;
   }
 
   function avaliarExpressao(cond: any, valor: string): boolean {
@@ -445,7 +456,13 @@ export default function EditarProdutoPage() {
                           <thead className="text-gray-400 bg-[#0f1419] uppercase">
                             <tr>
                               <th className="w-16 px-4 py-2 text-center">Ações</th>
-                              <th className="px-4 py-2">Operador</th>
+                              <th className="px-4 py-2">País de Origem</th>
+                              <th className="px-4 py-2">Conhecido</th>
+                              <th className="px-4 py-2">CPF/CNPJ/TIN</th>
+                              <th className="px-4 py-2">Código</th>
+                              <th className="px-4 py-2">Código Interno</th>
+                              <th className="px-4 py-2">Nome</th>
+                              <th className="px-4 py-2">Endereço</th>
                             </tr>
                           </thead>
                           <tbody>
@@ -456,9 +473,15 @@ export default function EditarProdutoPage() {
                                     <Trash2 size={16} />
                                   </button>
                                 </td>
+                                <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.pais.nome : ''}</td>
+                                <td className="px-4 py-1">{op.conhecido === 'sim' ? 'Sim' : 'Não'}</td>
                                 <td className="px-4 py-1">
-                                  {op.conhecido === 'sim' ? op.operador?.nome : 'Não informado'} - {op.paisCodigo}
+                                  {op.conhecido === 'sim' ? (op.operador?.tin || formatCPFOrCNPJ(op.operador?.cnpjRaizResponsavel)) : ''}
                                 </td>
+                                <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.codigo || '' : ''}</td>
+                                <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.codigoInterno || '' : ''}</td>
+                                <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.nome || '' : ''}</td>
+                                <td className="px-4 py-1">{op.conhecido === 'sim' ? formatarEndereco(op.operador) : ''}</td>
                               </tr>
                             ))}
                           </tbody>

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -12,7 +12,7 @@ import { useToast } from '@/components/ui/ToastContext';
 import { useRouter } from 'next/router';
 import api from '@/lib/api';
 import { PageLoader } from '@/components/ui/PageLoader';
-import { formatCPFOrCNPJ } from '@/lib/validation';
+import { formatCPFOrCNPJ, formatCEP } from '@/lib/validation';
 import { Trash2 } from 'lucide-react';
 import { useOperadorEstrangeiro, OperadorEstrangeiro } from '@/hooks/useOperadorEstrangeiro';
 import { OperadorEstrangeiroSelector } from '@/components/operadores-estrangeriros/OperadorEstrangeiroSelector';
@@ -175,6 +175,16 @@ export default function NovoProdutoPage() {
 
   function removerOperador(index: number) {
     setOperadores(prev => prev.filter((_, i) => i !== index));
+  }
+
+  function formatarEndereco(op?: OperadorEstrangeiro | null) {
+    if (!op) return '';
+    const partes = [] as string[];
+    if (op.logradouro) partes.push(op.logradouro);
+    if (op.cidade) partes.push(op.cidade);
+    if (op.subdivisao) partes.push(op.subdivisao.nome);
+    const endereco = partes.join(', ');
+    return op.codigoPostal ? `${endereco} - ${formatCEP(op.codigoPostal)}` : endereco;
   }
 
   function avaliarExpressao(cond: any, valor: string): boolean {
@@ -493,7 +503,13 @@ export default function NovoProdutoPage() {
                                   <thead className="text-gray-400 bg-[#0f1419] uppercase">
                                     <tr>
                                       <th className="w-16 px-4 py-2 text-center">Ações</th>
-                                      <th className="px-4 py-2">Operador</th>
+                                      <th className="px-4 py-2">País de Origem</th>
+                                      <th className="px-4 py-2">Conhecido</th>
+                                      <th className="px-4 py-2">CPF/CNPJ/TIN</th>
+                                      <th className="px-4 py-2">Código</th>
+                                      <th className="px-4 py-2">Código Interno</th>
+                                      <th className="px-4 py-2">Nome</th>
+                                      <th className="px-4 py-2">Endereço</th>
                                     </tr>
                                   </thead>
                                   <tbody>
@@ -504,9 +520,15 @@ export default function NovoProdutoPage() {
                                             <Trash2 size={16} />
                                           </button>
                                         </td>
+                                        <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.pais.nome : ''}</td>
+                                        <td className="px-4 py-1">{op.conhecido === 'sim' ? 'Sim' : 'Não'}</td>
                                         <td className="px-4 py-1">
-                                          {op.conhecido === 'sim' ? op.operador?.nome : 'Não informado'} - {op.paisCodigo}
+                                          {op.conhecido === 'sim' ? (op.operador?.tin || formatCPFOrCNPJ(op.operador?.cnpjRaizResponsavel)) : ''}
                                         </td>
+                                        <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.codigo || '' : ''}</td>
+                                        <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.codigoInterno || '' : ''}</td>
+                                        <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.nome || '' : ''}</td>
+                                        <td className="px-4 py-1">{op.conhecido === 'sim' ? formatarEndereco(op.operador) : ''}</td>
                                       </tr>
                                     ))}
                                   </tbody>


### PR DESCRIPTION
## Resumo
- diminuir altura e fonte do cabeçalho dos cards
- exibir dados completos dos operadores estrangeiros nos cadastros de produto

## Testes
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_68754335850483309b0f9a584d7321ff