### PR TITLE
Adicionar denominação e descrição ao produto

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -183,6 +183,8 @@ model Produto {
   status                    ProdutoStatus     @map("status")
   ncmCodigo                 String            @map("ncm_codigo")
   modalidade                String?           @map("modalidade")
+  denominacao               String?           @map("denominacao")
+  descricao                 String?           @map("descricao")
   catalogoId                Int               @map("catalogo_id")
   catalogo                  Catalogo          @relation(fields: [catalogoId], references: [id])
   criadoEm                  DateTime          @default(now()) @map("criado_em")

--- a/backend/src/services/produto.service.ts
+++ b/backend/src/services/produto.service.ts
@@ -10,6 +10,8 @@ export interface CreateProdutoDTO {
   ncmCodigo: string;
   modalidade: string;
   catalogoId: number;
+  denominacao?: string;
+  descricao?: string;
   valoresAtributos?: Prisma.InputJsonValue;
   codigosInternos?: string[];
   operadoresEstrangeiros?: OperadorEstrangeiroProdutoInput[];
@@ -19,6 +21,8 @@ export interface CreateProdutoDTO {
 export interface UpdateProdutoDTO {
   modalidade?: string;
   status?: 'RASCUNHO' | 'ATIVO' | 'INATIVO';
+  denominacao?: string;
+  descricao?: string;
   valoresAtributos?: Prisma.InputJsonValue;
   codigosInternos?: string[];
   operadoresEstrangeiros?: OperadorEstrangeiroProdutoInput[];
@@ -80,6 +84,8 @@ export class ProdutoService {
           status: 'RASCUNHO',
           ncmCodigo: data.ncmCodigo,
           modalidade: data.modalidade,
+          denominacao: data.denominacao ?? null,
+          descricao: data.descricao ?? null,
           catalogoId: data.catalogoId,
           versaoEstruturaAtributos: 1,
           criadoPor: data.criadoPor || null,
@@ -145,6 +151,8 @@ export class ProdutoService {
         data: {
           modalidade: data.modalidade,
           status: data.status,
+          denominacao: data.denominacao,
+          descricao: data.descricao,
           versaoEstruturaAtributos: atual.versaoEstruturaAtributos
         },
         include: { codigosInternos: true, operadoresEstrangeiros: true }

--- a/backend/src/validators/produto.validator.ts
+++ b/backend/src/validators/produto.validator.ts
@@ -6,6 +6,8 @@ export const createProdutoSchema = z.object({
   ncmCodigo: z.string().length(8),
   modalidade: z.string().min(1),
   catalogoId: z.number().int(),
+  denominacao: z.string().max(100).optional(),
+  descricao: z.string().optional(),
   valoresAtributos: z.record(z.any()).optional(),
   codigosInternos: z.array(z.string().max(50)).optional(),
   operadoresEstrangeiros: z.array(z.object({
@@ -19,6 +21,8 @@ export const createProdutoSchema = z.object({
 export const updateProdutoSchema = z.object({
   modalidade: z.string().min(1).optional(),
   status: z.enum(['RASCUNHO', 'ATIVO', 'INATIVO']).optional(),
+  denominacao: z.string().max(100).optional(),
+  descricao: z.string().optional(),
   valoresAtributos: z.record(z.any()).optional(),
   codigosInternos: z.array(z.string().max(50)).optional(),
   operadoresEstrangeiros: z.array(z.object({

--- a/frontend/pages/produtos.tsx
+++ b/frontend/pages/produtos.tsx
@@ -20,7 +20,8 @@ interface Produto {
   catalogoNumero?: number;
   catalogoNome?: string;
   catalogoCpfCnpj?: string;
-  nome?: string;
+  denominacao?: string;
+  descricao?: string;
   codigoInterno?: string;
   situacao?: string;
 }
@@ -62,7 +63,7 @@ export default function ProdutosPage() {
     return (
       (p.codigo || '').toLowerCase().includes(termo) ||
       p.ncmCodigo.toLowerCase().includes(termo) ||
-      (p.nome && p.nome.toLowerCase().includes(termo))
+      (p.denominacao && p.denominacao.toLowerCase().includes(termo))
     );
   });
 
@@ -175,7 +176,7 @@ export default function ProdutosPage() {
                     <td className="px-4 py-3 font-mono text-[#f59e0b]">{produto.catalogoNumero ?? '-'}</td>
                     <td className="px-4 py-3">{produto.catalogoNome ?? '-'}</td>
                     <td className="px-4 py-3">{produto.catalogoCpfCnpj ?? '-'}</td>
-                    <td className="px-4 py-3">{produto.nome ?? produto.codigo ?? '-'}</td>
+                    <td className="px-4 py-3">{produto.denominacao ?? produto.codigo ?? '-'}</td>
                     <td className="px-4 py-3">{produto.codigoInterno ?? '-'}</td>
                     <td className="px-4 py-3 font-mono">{produto.ncmCodigo}</td>
                     <td className="px-4 py-3">{produto.status}</td>

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -41,6 +41,8 @@ export default function EditarProdutoPage() {
   const [ncm, setNcm] = useState('');
   const [ncmDescricao, setNcmDescricao] = useState('');
   const [modalidade, setModalidade] = useState('IMPORTACAO');
+  const [denominacao, setDenominacao] = useState('');
+  const [descricao, setDescricao] = useState('');
   const [estrutura, setEstrutura] = useState<AtributoEstrutura[]>([]);
   const [valores, setValores] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
@@ -279,6 +281,8 @@ export default function EditarProdutoPage() {
           operador: o.operadorEstrangeiro || null
         }))
       );
+      setDenominacao(dados.denominacao || '');
+      setDescricao(dados.descricao || '');
       setCatalogoNome(dados.catalogo?.nome || '');
       setNcm(dados.ncmCodigo);
       setModalidade(dados.modalidade);
@@ -312,6 +316,8 @@ export default function EditarProdutoPage() {
     try {
       await api.put(`/produtos/${id}`, {
         modalidade,
+        denominacao,
+        descricao,
         valoresAtributos: valores,
         codigosInternos,
         operadoresEstrangeiros: operadores.map(o => ({
@@ -378,6 +384,19 @@ export default function EditarProdutoPage() {
               content: (
                 <div className="grid grid-cols-3 gap-4 text-sm">
                   <Input label="Código" value={codigo || '-'} disabled />
+                  <Input
+                    label="Nome do Produto"
+                    className="col-span-3"
+                    value={denominacao}
+                    onChange={e => setDenominacao(e.target.value)}
+                  />
+                  <textarea
+                    className="col-span-3 w-full px-2 py-1 text-sm bg-[#1e2126] border border-gray-700 text-white rounded-md focus:outline-none focus:ring focus:border-blue-500"
+                    placeholder="Descrição do Produto"
+                    rows={4}
+                    value={descricao}
+                    onChange={e => setDescricao(e.target.value)}
+                  />
 
                   <Card
                     headerTitle="Códigos Internos"

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -44,6 +44,8 @@ export default function NovoProdutoPage() {
   const [ncmDescricao, setNcmDescricao] = useState('');
   const [unidadeMedida, setUnidadeMedida] = useState('');
   const [modalidade, setModalidade] = useState('IMPORTACAO');
+  const [denominacao, setDenominacao] = useState('');
+  const [descricao, setDescricao] = useState('');
   const [estrutura, setEstrutura] = useState<AtributoEstrutura[]>([]);
   const [valores, setValores] = useState<Record<string, string>>({});
   const [loadingEstrutura, setLoadingEstrutura] = useState(false);
@@ -327,6 +329,8 @@ export default function NovoProdutoPage() {
         ncmCodigo: ncm,
         modalidade,
         catalogoId: Number(catalogoId),
+        denominacao,
+        descricao,
         valoresAtributos: valores,
         codigosInternos,
         operadoresEstrangeiros: operadores.map(o => ({
@@ -419,12 +423,17 @@ export default function NovoProdutoPage() {
                         <div className="grid grid-cols-3 gap-4 text-sm">
                           <Input
                             label="Nome do Produto"
-                            className="col-span-1"
+                            className="col-span-3"
+                            value={denominacao}
+                            onChange={e => setDenominacao(e.target.value)}
                           />
 
-                          <Input
-                            label="Descrição do Produto"
-                            className="col-span-1"
+                          <textarea
+                            className="col-span-3 w-full px-2 py-1 text-sm bg-[#1e2126] border border-gray-700 text-white rounded-md focus:outline-none focus:ring focus:border-blue-500"
+                            placeholder="Descrição do Produto"
+                            rows={4}
+                            value={descricao}
+                            onChange={e => setDescricao(e.target.value)}
                           />
 
                           <div className="col-span-3">

--- a/scripts_banco_catalogo_produtos.sql
+++ b/scripts_banco_catalogo_produtos.sql
@@ -178,6 +178,8 @@ DELIMITER ;
         status ENUM('RASCUNHO', 'ATIVO', 'INATIVO') DEFAULT 'RASCUNHO',
         ncm_codigo VARCHAR(8) NOT NULL,
         modalidade VARCHAR(50),
+        denominacao VARCHAR(100),
+        descricao TEXT,
         -- Rastreabilidade
         atualizado_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
         criado_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Resumo
- incluir campos `denominacao` e `descricao` na tabela `produto`
- permitir gravar e editar os novos campos via API
- validar novos campos no backend
- exibir e editar denominação e descrição nas telas de produto
- ajustar script SQL

## Testes
- `npm run build:all`
- `npm test -- --passWithNoTests` *(falhou: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68754ec19f748330bd83ebe1f9648414