### PR TITLE
Ajuste de alinhamento no cadastro de produtos

### DIFF
--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -499,8 +499,15 @@ export default function NovoProdutoPage() {
                               />
                               {novoOperador.conhecido === 'sim' && (
                                 <div className="flex items-end gap-2">
-                                  <Input label="Operador" value={novoOperador.operador?.nome || ''} readOnly className="flex-1" />
-                                  <Button type="button" onClick={() => setSelectorOpen(true)}>Buscar</Button>
+                                  <Input
+                                    label="Operador"
+                                    value={novoOperador.operador?.nome || ''}
+                                    readOnly
+                                    className="flex-1 mb-0"
+                                  />
+                                  <Button type="button" onClick={() => setSelectorOpen(true)}>
+                                    Buscar
+                                  </Button>
                                 </div>
                               )}
                             </div>


### PR DESCRIPTION
## Summary
- alinhar input de operador estrangeiro ao lado do radio `Conhecido?`

## Testing
- `npm run build:all` *(falhou: npm não encontrado)*
- `npm test -- --passWithNoTests` *(falhou: npm não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_687555547ba883309ca347ba451b17f3