### PR TITLE
Corrige acesso nulo em país do operador

### DIFF
--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -492,7 +492,7 @@ export default function EditarProdutoPage() {
                                     <Trash2 size={16} />
                                   </button>
                                 </td>
-                                <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.pais.nome : ''}</td>
+                                <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.pais?.nome : ''}</td>
                                 <td className="px-4 py-1">{op.conhecido === 'sim' ? 'Sim' : 'Não'}</td>
                                 <td className="px-4 py-1">
                                   {op.conhecido === 'sim' ? (op.operador?.tin || formatCPFOrCNPJ(op.operador?.cnpjRaizResponsavel)) : ''}

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -536,7 +536,7 @@ export default function NovoProdutoPage() {
                                             <Trash2 size={16} />
                                           </button>
                                         </td>
-                                        <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.pais.nome : ''}</td>
+                                        <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.pais?.nome : ''}</td>
                                         <td className="px-4 py-1">{op.conhecido === 'sim' ? 'Sim' : 'Não'}</td>
                                         <td className="px-4 py-1">
                                           {op.conhecido === 'sim' ? (op.operador?.tin || formatCPFOrCNPJ(op.operador?.cnpjRaizResponsavel)) : ''}


### PR DESCRIPTION
## Descrição
- evita erro ao abrir edição de produto quando o operador estrangeiro não tem país cadastrado

## Testes realizados
- `npm run build:all`

------
https://chatgpt.com/codex/tasks/task_e_687559c4fce883309b7e7ddcfa7ee446