### PR TITLE
Corrige falha ao editar produto

### DIFF
--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -492,7 +492,7 @@ export default function EditarProdutoPage() {
                                     <Trash2 size={16} />
                                   </button>
                                 </td>
-                                <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.pais.nome : ''}</td>
+                                <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.pais?.nome : ''}</td>
                                 <td className="px-4 py-1">{op.conhecido === 'sim' ? 'Sim' : 'Não'}</td>
                                 <td className="px-4 py-1">
                                   {op.conhecido === 'sim' ? (op.operador?.tin || formatCPFOrCNPJ(op.operador?.cnpjRaizResponsavel)) : ''}

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -536,7 +536,7 @@ export default function NovoProdutoPage() {
                                             <Trash2 size={16} />
                                           </button>
                                         </td>
-                                        <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.pais.nome : ''}</td>
+                                        <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.pais?.nome : ''}</td>
                                         <td className="px-4 py-1">{op.conhecido === 'sim' ? 'Sim' : 'Não'}</td>
                                         <td className="px-4 py-1">
                                           {op.conhecido === 'sim' ? (op.operador?.tin || formatCPFOrCNPJ(op.operador?.cnpjRaizResponsavel)) : ''}


### PR DESCRIPTION
## Resumo
- corrigido acesso a `pais.nome` com optional chaining

## Testes
- `npm run build:all`
- `npm --prefix backend test` *(falha: DATABASE_URL ausente)*

------
https://chatgpt.com/codex/tasks/task_e_68755b4e1f9083309553c62f1bbdca08