### PR TITLE
Corrige largura do card de operadores

### DIFF
--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -457,7 +457,7 @@ export default function EditarProdutoPage() {
                   <Card
                     headerTitle="Operadores Estrangeiros"
                     headerClassName="bg-[#1a1f2b] px-4 py-2"
-                    className="mt-4"
+                    className="col-span-3 mt-4"
                   >
                     <div className="grid grid-cols-3 gap-4 mb-4">
                       <Select

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -494,7 +494,7 @@ export default function NovoProdutoPage() {
                           <Card
                             headerTitle="Operadores Estrangeiros"
                             headerClassName="bg-[#1a1f2b] px-4 py-2"
-                            className="mt-4"
+                            className="col-span-3 mt-4"
                           >
                             <div className="grid grid-cols-3 gap-4 mb-4">
                               <Select


### PR DESCRIPTION
## Resumo
- Corrige a classe do card de Operadores Estrangeiros nas telas de criação e edição de produtos para ocupar toda a largura disponível.

## Testes
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_6875ac5f9a08833085c715b060f047f9