### PR TITLE
Exibir país na lista de operadores

### DIFF
--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -37,7 +37,7 @@ export default function EditarProdutoPage() {
   const [operadores, setOperadores] = useState<Array<{ paisCodigo: string; conhecido: string; operador?: OperadorEstrangeiro | null }>>([]);
   const [novoOperador, setNovoOperador] = useState<{ paisCodigo: string; conhecido: string; operador?: OperadorEstrangeiro | null }>({ paisCodigo: '', conhecido: 'nao', operador: undefined });
   const [selectorOpen, setSelectorOpen] = useState(false);
-  const { getPaisOptions } = useOperadorEstrangeiro();
+  const { getPaisOptions, getPaisNome } = useOperadorEstrangeiro();
   const [ncm, setNcm] = useState('');
   const [ncmDescricao, setNcmDescricao] = useState('');
   const [modalidade, setModalidade] = useState('IMPORTACAO');
@@ -506,7 +506,7 @@ export default function EditarProdutoPage() {
                                     <Trash2 size={16} />
                                   </button>
                                 </td>
-                                <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.pais?.nome : ''}</td>
+                                <td className="px-4 py-1">{op.operador?.pais?.nome || getPaisNome(op.paisCodigo)}</td>
                                 <td className="px-4 py-1">{op.conhecido === 'sim' ? 'Sim' : 'Não'}</td>
                                 <td className="px-4 py-1">
                                   {op.conhecido === 'sim' ? (op.operador?.tin || formatCPFOrCNPJ(op.operador?.cnpjRaizResponsavel)) : ''}

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -38,7 +38,7 @@ export default function NovoProdutoPage() {
   const [operadores, setOperadores] = useState<Array<{ paisCodigo: string; conhecido: string; operador?: OperadorEstrangeiro | null }>>([]);
   const [novoOperador, setNovoOperador] = useState<{ paisCodigo: string; conhecido: string; operador?: OperadorEstrangeiro | null }>({ paisCodigo: '', conhecido: 'nao', operador: undefined });
   const [selectorOpen, setSelectorOpen] = useState(false);
-  const { getPaisOptions, buscarOperadorPorId } = useOperadorEstrangeiro();
+  const { getPaisOptions, buscarOperadorPorId, getPaisNome } = useOperadorEstrangeiro();
   const [catalogos, setCatalogos] = useState<Array<{ id: number; nome: string; cpf_cnpj: string | null }>>([]);
   const [ncm, setNcm] = useState('');
   const [ncmDescricao, setNcmDescricao] = useState('');
@@ -550,7 +550,7 @@ export default function NovoProdutoPage() {
                                             <Trash2 size={16} />
                                           </button>
                                         </td>
-                                        <td className="px-4 py-1">{op.conhecido === 'sim' ? op.operador?.pais?.nome : ''}</td>
+                                        <td className="px-4 py-1">{op.operador?.pais?.nome || getPaisNome(op.paisCodigo)}</td>
                                         <td className="px-4 py-1">{op.conhecido === 'sim' ? 'Sim' : 'Não'}</td>
                                         <td className="px-4 py-1">
                                           {op.conhecido === 'sim' ? (op.operador?.tin || formatCPFOrCNPJ(op.operador?.cnpjRaizResponsavel)) : ''}


### PR DESCRIPTION
## Resumo
- exibir o nome do país utilizando `getPaisNome` na tabela de operadores
- importar `getPaisNome` nas páginas de novo e edição de produto

## Testes
- `npm run build:all`
- `npm test -- --passWithNoTests` *(falha: script inexistente)*
- `cd backend && npm test -- --passWithNoTests` *(falha: DATABASE_URL não definida)*

------
https://chatgpt.com/codex/tasks/task_e_68764ee47e9c83308d8121773e14baa5