### PR TITLE
Corrige detalhes de erros nos produtos

### DIFF
--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -337,7 +337,10 @@ export default function EditarProdutoPage() {
   function handleApiError(error: any) {
     if (error.response?.status === 400 && error.response?.data?.details) {
       const details = error.response.data.details
-        .map((d: any) => `${d.field}: ${d.message}`)
+        .map((d: any) => {
+          const nome = mapaEstrutura.get(d.field)?.nome ?? d.field;
+          return `${nome}: ${d.message}`;
+        })
         .join('; ');
       addToast(`Erro de validação: ${details}`, 'error');
     } else if (error.response?.data?.error) {

--- a/frontend/pages/produtos/novo.tsx
+++ b/frontend/pages/produtos/novo.tsx
@@ -350,7 +350,10 @@ export default function NovoProdutoPage() {
   function handleApiError(error: any) {
     if (error.response?.status === 400 && error.response?.data?.details) {
       const details = error.response.data.details
-        .map((d: any) => `${d.field}: ${d.message}`)
+        .map((d: any) => {
+          const nome = mapaEstrutura.get(d.field)?.nome ?? d.field;
+          return `${nome}: ${d.message}`;
+        })
         .join('; ');
       addToast(`Erro de valida\u00e7\u00e3o: ${details}`, 'error');
     } else if (error.response?.data?.error) {


### PR DESCRIPTION
## Resumo
- melhorado tratamento de erros exibidos nos formulários de criação e edição de produtos

## Testes
- `npm test -- --passWithNoTests` *(falhou: Missing script: "test")*
- `npm run build:all`
- `npm build` *(falhou: Unknown command: "build")*


------
https://chatgpt.com/codex/tasks/task_e_68765d0308308330aa574427a7fb1d39