### PR TITLE
Adiciona orientações nos atributos

### DIFF
--- a/backend/src/services/__tests__/atributo-legacy.service.test.ts
+++ b/backend/src/services/__tests__/atributo-legacy.service.test.ts
@@ -22,6 +22,7 @@ describe('AtributoLegacyService', () => {
           tamanho_maximo: null,
           casas_decimais: null,
           mascara: null,
+          orientacao_preenchimento: null,
           descricao_condicao: 'desc',
           condicao: '{invalid',
           dominio_codigo: null,

--- a/backend/src/services/atributo-legacy.service.ts
+++ b/backend/src/services/atributo-legacy.service.ts
@@ -14,6 +14,7 @@ export interface AtributoEstruturaDTO {
   obrigatorio: boolean
   multivalorado: boolean
   validacoes: Record<string, any>
+  orientacaoPreenchimento?: string
   dominio?: DominioDTO[]
   descricaoCondicao?: string
   condicao?: any
@@ -33,13 +34,14 @@ export class AtributoLegacyService {
       tamanho_maximo: number | null
       casas_decimais: number | null
       mascara: string | null
+      orientacao_preenchimento: string | null
       parent_codigo: string | null
       dominio_codigo: string | null
       dominio_descricao: string | null
     }>>(Prisma.sql`
       SELECT a.codigo, a.nome_apresentacao, a.forma_preenchimento,
              av.obrigatorio, COALESCE(av.multivalorado, a.multivalorado) AS multivalorado,
-             a.tamanho_maximo, a.casas_decimais, a.mascara, a.parent_codigo,
+             a.tamanho_maximo, a.casas_decimais, a.mascara, a.orientacao_preenchimento, a.parent_codigo,
              ad.codigo AS dominio_codigo, ad.descricao AS dominio_descricao
       FROM atributo_vinculo av
         JOIN atributo a ON a.codigo = av.codigo
@@ -58,6 +60,7 @@ export class AtributoLegacyService {
       tamanho_maximo: number | null
       casas_decimais: number | null
       mascara: string | null
+      orientacao_preenchimento: string | null
       descricao_condicao: string | null
       condicao: string | null
       dominio_codigo: string | null
@@ -66,7 +69,7 @@ export class AtributoLegacyService {
       SELECT ac.atributo_codigo AS condicionante_codigo,
              ac.codigo, ac.nome_apresentacao, ac.forma_preenchimento,
              ac.obrigatorio, ac.multivalorado, ac.tamanho_maximo,
-             ac.casas_decimais, ac.mascara,
+             ac.casas_decimais, ac.mascara, ac.orientacao_preenchimento,
              ac.descricao_condicao, ac.condicao, ad.codigo AS dominio_codigo,
              ad.descricao AS dominio_descricao
       FROM atributo_condicionado ac
@@ -91,6 +94,7 @@ export class AtributoLegacyService {
           multivalorado: Boolean(row.multivalorado),
           validacoes: {},
           parentCodigo: row.parent_codigo || undefined,
+          orientacaoPreenchimento: row.orientacao_preenchimento || undefined,
           dominio: []
         }
         if (row.tamanho_maximo !== null) attr.validacoes.tamanho_maximo = row.tamanho_maximo
@@ -115,8 +119,9 @@ export class AtributoLegacyService {
           validacoes: {},
           parentCodigo: row.condicionante_codigo,
           condicionanteCodigo: row.condicionante_codigo,
-        descricaoCondicao: row.descricao_condicao || undefined,
-        condicao: row.condicao ? parseJsonSafe(row.condicao) : undefined,
+          descricaoCondicao: row.descricao_condicao || undefined,
+          condicao: row.condicao ? parseJsonSafe(row.condicao) : undefined,
+          orientacaoPreenchimento: row.orientacao_preenchimento || undefined,
           dominio: []
         }
         if (row.tamanho_maximo !== null) attr.validacoes.tamanho_maximo = row.tamanho_maximo
@@ -127,6 +132,8 @@ export class AtributoLegacyService {
         attr.parentCodigo = row.condicionante_codigo
         attr.descricaoCondicao = row.descricao_condicao || attr.descricaoCondicao
         if (row.condicao) attr.condicao = parseJsonSafe(row.condicao)
+        if (row.orientacao_preenchimento)
+          attr.orientacaoPreenchimento = row.orientacao_preenchimento
       }
       if (row.dominio_codigo) {
         if (!attr.dominio) attr.dominio = []

--- a/frontend/components/ui/Hint.tsx
+++ b/frontend/components/ui/Hint.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import { CircleHelp } from 'lucide-react';
+
+interface HintProps {
+  text: string;
+}
+
+export function Hint({ text }: HintProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative inline-block ml-1">
+      <CircleHelp
+        size={14}
+        className="text-gray-400 cursor-pointer"
+        onClick={() => setOpen((v) => !v)}
+      />
+      {open && (
+        <div className="absolute z-50 w-64 p-2 text-xs text-gray-300 bg-[#1e2126] border border-gray-700 rounded-md mt-1">
+          {text}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/ui/Input.tsx
+++ b/frontend/components/ui/Input.tsx
@@ -1,18 +1,21 @@
 // frontend/components/ui/Input.tsx
 import React from 'react';
+import { Hint } from './Hint';
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
+  hint?: string;
 }
 
-export function Input({ label, error, className = '', ...props }: InputProps) {
+export function Input({ label, error, hint, className = '', ...props }: InputProps) {
   return (
     <div className={`mb-4 ${className}`}>
       {label && (
         <label className="block text-sm font-medium mb-1 text-gray-300" htmlFor={props.id}>
           {label}
           {props.required && <span className="text-red-400 ml-1">*</span>}
+          {hint && <Hint text={hint} />}
         </label>
       )}
       <input

--- a/frontend/components/ui/RadioGroup.tsx
+++ b/frontend/components/ui/RadioGroup.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Hint } from './Hint';
 
 interface Option {
   value: string;
@@ -14,6 +15,7 @@ interface RadioGroupProps {
   name?: string;
   className?: string;
   error?: string;
+  hint?: string;
 }
 
 export function RadioGroup({
@@ -24,7 +26,8 @@ export function RadioGroup({
   required = false,
   name,
   className = '',
-  error
+  error,
+  hint
 }: RadioGroupProps) {
   return (
     <div className={`mb-4 ${className}`}>
@@ -32,6 +35,7 @@ export function RadioGroup({
         <label className="block text-sm font-medium mb-1 text-gray-300">
           {label}
           {required && <span className="text-red-400 ml-1">*</span>}
+          {hint && <Hint text={hint} />}
         </label>
       )}
       <div className="flex items-center gap-4 text-sm">

--- a/frontend/components/ui/Select.tsx
+++ b/frontend/components/ui/Select.tsx
@@ -1,20 +1,23 @@
 // frontend/components/ui/Select.tsx (CORRIGIDO)
 import React from 'react';
+import { Hint } from './Hint';
 
 interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
   label?: string;
   options: Array<{ value: string; label: string }>;
   error?: string;
   placeholder?: string;
+  hint?: string;
 }
 
-export function Select({ label, options, className = '', error, placeholder = 'Selecione...', ...props }: SelectProps) {
+export function Select({ label, options, className = '', error, placeholder = 'Selecione...', hint, ...props }: SelectProps) {
   return (
     <div className={`mb-4 ${className}`}>
       {label && (
         <label className="block text-sm font-medium mb-1 text-gray-300" htmlFor={props.id}>
           {label}
           {props.required && <span className="text-red-400 ml-1">*</span>}
+          {hint && <Hint text={hint} />}
         </label>
       )}
       <select

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -17,6 +17,7 @@ import { Trash2, BrainCog, ArrowLeft } from 'lucide-react';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { useOperadorEstrangeiro, OperadorEstrangeiro } from '@/hooks/useOperadorEstrangeiro';
 import { OperadorEstrangeiroSelector } from '@/components/operadores-estrangeriros/OperadorEstrangeiroSelector';
+import { Hint } from '@/components/ui/Hint';
 
 interface AtributoEstrutura {
   codigo: string;
@@ -31,6 +32,7 @@ interface AtributoEstrutura {
   descricaoCondicao?: string;
   condicao?: any;
   parentCodigo?: string;
+  orientacaoPreenchimento?: string;
   subAtributos?: AtributoEstrutura[];
 }
 
@@ -279,6 +281,7 @@ export default function ProdutoPage() {
           <Select
             key={attr.codigo}
             label={attr.nome}
+            hint={attr.orientacaoPreenchimento}
             required={attr.obrigatorio}
             options={
               attr.dominio?.map(d => ({
@@ -296,6 +299,7 @@ export default function ProdutoPage() {
           <RadioGroup
             key={attr.codigo}
             label={attr.nome}
+            hint={attr.orientacaoPreenchimento}
             required={attr.obrigatorio}
             options={[
               { value: 'true', label: 'Sim' },
@@ -310,6 +314,7 @@ export default function ProdutoPage() {
           <Input
             key={attr.codigo}
             label={attr.nome}
+            hint={attr.orientacaoPreenchimento}
             type="number"
             required={attr.obrigatorio}
             value={value}
@@ -321,6 +326,7 @@ export default function ProdutoPage() {
           <Input
             key={attr.codigo}
             label={attr.nome}
+            hint={attr.orientacaoPreenchimento}
             type="number"
             step="0.01"
             required={attr.obrigatorio}
@@ -351,6 +357,9 @@ export default function ProdutoPage() {
                   {attr.obrigatorio && (
                     <span className="text-red-400 ml-1">*</span>
                   )}
+                  {attr.orientacaoPreenchimento && (
+                    <Hint text={attr.orientacaoPreenchimento} />
+                  )}
                 </label>
                 <textarea
                   id={attr.codigo}
@@ -371,6 +380,7 @@ export default function ProdutoPage() {
             <Input
               key={attr.codigo}
               label={attr.nome}
+              hint={attr.orientacaoPreenchimento}
               required={attr.obrigatorio}
               value={value}
               onChange={e => handleValor(attr.codigo, e.target.value)}
@@ -383,6 +393,7 @@ export default function ProdutoPage() {
           <Input
             key={attr.codigo}
             label={attr.nome}
+            hint={attr.orientacaoPreenchimento}
             required={attr.obrigatorio}
             value={value}
             onChange={e => handleValor(attr.codigo, e.target.value)}


### PR DESCRIPTION
## Resumo
- recupera orientacao_preenchimento do banco legacy
- exibe orientações nos campos de atributos dinâmicos
- inclui componente Hint para mostrar dicas

## Testes
- `npm test --silent --prefix backend` *(falhou: DATABASE_URL ausente)*
- `npm build` *(falhou: comando não definido)*

------
https://chatgpt.com/codex/tasks/task_e_6887770a4918833096aad4b5a10ff6d5