### PR TITLE
Ajuste no componente Hint

### DIFF
--- a/frontend/components/ui/Hint.tsx
+++ b/frontend/components/ui/Hint.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { CircleHelp } from 'lucide-react';
 
 interface HintProps {
@@ -7,11 +7,27 @@ interface HintProps {
 
 export function Hint({ text }: HintProps) {
   const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [open]);
+
   return (
-    <div className="relative inline-block ml-1">
+    <div className="relative inline-block ml-1" ref={ref}>
       <CircleHelp
         size={14}
-        className="text-gray-400 cursor-pointer"
+        className="text-[#f59e0b] cursor-pointer"
         onClick={() => setOpen((v) => !v)}
       />
       {open && (


### PR DESCRIPTION
## Resumo
- altera a cor do ícone do Hint para laranja
- fecha o balão de orientação ao clicar fora

## Testes
- `npm test` *(falha: variáveis de ambiente ausentes)*
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_6887861aa62c83308d8703ca0cb4acbf