### PR TITLE
Aprovação automática de produto ao preencher atributos obrigatórios

### DIFF
--- a/backend/src/services/__tests__/produto.service.test.ts
+++ b/backend/src/services/__tests__/produto.service.test.ts
@@ -1,0 +1,24 @@
+import { ProdutoService } from '../produto.service'
+import { AtributoEstruturaDTO } from '../atributo-legacy.service'
+
+describe('ProdutoService - atributos obrigatórios', () => {
+  it('retorna verdadeiro quando todos obrigatórios preenchidos', () => {
+    const service = new ProdutoService()
+    const estrutura: AtributoEstruturaDTO[] = [
+      { codigo: 'A', nome: 'A', tipo: 'TEXTO', obrigatorio: true, multivalorado: false, validacoes: {} },
+      { codigo: 'B', nome: 'B', tipo: 'TEXTO', obrigatorio: true, multivalorado: false, validacoes: {} }
+    ]
+    const resultado = (service as any).todosObrigatoriosPreenchidos({ A: '1', B: '2' }, estrutura)
+    expect(resultado).toBe(true)
+  })
+
+  it('retorna falso quando algum obrigatório não preenchido', () => {
+    const service = new ProdutoService()
+    const estrutura: AtributoEstruturaDTO[] = [
+      { codigo: 'A', nome: 'A', tipo: 'TEXTO', obrigatorio: true, multivalorado: false, validacoes: {} },
+      { codigo: 'B', nome: 'B', tipo: 'TEXTO', obrigatorio: true, multivalorado: false, validacoes: {} }
+    ]
+    const resultado = (service as any).todosObrigatoriosPreenchidos({ A: '1' }, estrutura)
+    expect(resultado).toBe(false)
+  })
+})


### PR DESCRIPTION
## Resumo
- aprova automaticamente o produto quando todos os atributos dinâmicos obrigatórios estão preenchidos
- adiciona testes para a verificação de atributos obrigatórios

## Testes
- `npm test` *(falhou: Can't reach database server at `localhost:3306`)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6892acdefa30833088a710577c2c6ec7