### PR TITLE
Ajusta status de produto pendente quando faltam obrigatórios

### DIFF
--- a/backend/src/services/__tests__/produto.service.test.ts
+++ b/backend/src/services/__tests__/produto.service.test.ts
@@ -1,5 +1,13 @@
 import { ProdutoService } from '../produto.service'
 import { AtributoEstruturaDTO } from '../atributo-legacy.service'
+import { catalogoPrisma } from '../../utils/prisma'
+
+jest.mock('../../utils/prisma', () => ({
+  catalogoPrisma: {
+    produto: { findUnique: jest.fn() },
+    $transaction: jest.fn()
+  }
+}))
 
 describe('ProdutoService - atributos obrigatórios', () => {
   it('retorna verdadeiro quando todos obrigatórios preenchidos', () => {
@@ -20,5 +28,42 @@ describe('ProdutoService - atributos obrigatórios', () => {
     ]
     const resultado = (service as any).todosObrigatoriosPreenchidos({ A: '1' }, estrutura)
     expect(resultado).toBe(false)
+  })
+})
+
+describe('ProdutoService - atualização de status', () => {
+  it('marca como PENDENTE quando faltam atributos obrigatórios', async () => {
+    const service = new ProdutoService()
+    const estrutura: AtributoEstruturaDTO[] = [
+      { codigo: 'A', nome: 'A', tipo: 'TEXTO', obrigatorio: true, multivalorado: false, validacoes: {} }
+    ]
+
+    jest.spyOn(service as any, 'obterEstruturaAtributos').mockResolvedValue(estrutura)
+
+    ;(catalogoPrisma.produto.findUnique as jest.Mock).mockResolvedValue({
+      id: 1,
+      status: 'APROVADO',
+      ncmCodigo: '001',
+      modalidade: '',
+      atributos: [{ valoresJson: { A: '1' } }]
+    })
+
+    const updateSpy = jest.fn().mockResolvedValue({})
+    ;(catalogoPrisma.$transaction as jest.Mock).mockImplementation(async (cb: any) =>
+      cb({
+        produto: { update: updateSpy },
+        produtoAtributos: { updateMany: jest.fn() },
+        codigoInternoProduto: { deleteMany: jest.fn(), createMany: jest.fn() },
+        operadorEstrangeiroProduto: { deleteMany: jest.fn(), createMany: jest.fn() }
+      })
+    )
+
+    await service.atualizar(1, { valoresAtributos: {} })
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'PENDENTE' })
+      })
+    )
   })
 })

--- a/backend/src/services/produto.service.ts
+++ b/backend/src/services/produto.service.ts
@@ -192,8 +192,10 @@ export class ProdutoService {
     const preencheuObrigatorios = this.todosObrigatoriosPreenchidos(valores, estrutura);
 
     return catalogoPrisma.$transaction(async tx => {
-      let status = data.status;
-      if (atual.status === 'PENDENTE' && preencheuObrigatorios) {
+      let status = data.status ?? atual.status;
+      if (!preencheuObrigatorios) {
+        status = 'PENDENTE';
+      } else if (atual.status === 'PENDENTE') {
         status = 'APROVADO';
       }
       const produto = await tx.produto.update({


### PR DESCRIPTION
## Resumo
- Define status `PENDENTE` ao atualizar produto com campos obrigatórios vazios
- Adiciona teste cobrindo atualização de status para produto sem obrigatórios

## Testes
- `npm test`
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_6892c1a335cc8330b56bfabbfdb64985