### PR TITLE
Adicionar botão de edição nas listagens

### DIFF
--- a/frontend/pages/catalogos/index.tsx
+++ b/frontend/pages/catalogos/index.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/Button';
 import { PageLoader } from '@/components/ui/PageLoader';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { useToast } from '@/components/ui/ToastContext';
-import { Plus, Trash2, AlertCircle } from 'lucide-react';
+import { Plus, Trash2, AlertCircle, Pencil } from 'lucide-react';
 import { useRouter } from 'next/router';
 import api from '@/lib/api';
 import { formatCPFOrCNPJ } from '@/lib/validation';
@@ -152,13 +152,18 @@ export default function CatalogosPage() {
               </thead>
               <tbody>
                 {catalogos.map((catalogo) => (
-                  <tr 
-                    key={catalogo.id} 
-                    className="border-b border-gray-700 hover:bg-[#1a1f2b] cursor-pointer transition-colors"
-                    onClick={() => editarCatalogo(catalogo.id)}
+                  <tr
+                    key={catalogo.id}
+                    className="border-b border-gray-700 hover:bg-[#1a1f2b] transition-colors"
                   >
-                    <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
-                      <button 
+                    <td className="px-4 py-3 flex gap-2">
+                      <button
+                        className="p-1 text-gray-300 hover:text-blue-500 transition-colors"
+                        onClick={() => editarCatalogo(catalogo.id)}
+                      >
+                        <Pencil size={16} />
+                      </button>
+                      <button
                         className="p-1 text-gray-300 hover:text-red-500 transition-colors"
                         onClick={() => confirmarExclusao(catalogo.id)}
                       >

--- a/frontend/pages/operadores-estrangeiros/index.tsx
+++ b/frontend/pages/operadores-estrangeiros/index.tsx
@@ -8,7 +8,7 @@ import { PageLoader } from '@/components/ui/PageLoader';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { useToast } from '@/components/ui/ToastContext';
 import { useOperadorEstrangeiro } from '@/hooks/useOperadorEstrangeiro';
-import { Plus, Trash2, AlertCircle, Search, Globe } from 'lucide-react';
+import { Plus, Trash2, AlertCircle, Search, Globe, Pencil } from 'lucide-react';
 import { useRouter } from 'next/router';
 import { formatCPFOrCNPJ } from '@/lib/validation';
 
@@ -223,13 +223,18 @@ export default function OperadoresEstrangeirosPage() {
               </thead>
               <tbody>
                 {operadoresFiltrados.map((operador) => (
-                  <tr 
-                    key={operador.id} 
-                    className="border-b border-gray-700 hover:bg-[#1a1f2b] cursor-pointer transition-colors"
-                    onClick={() => editarOperador(operador.id)}
+                  <tr
+                    key={operador.id}
+                    className="border-b border-gray-700 hover:bg-[#1a1f2b] transition-colors"
                   >
-                    <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
-                      <button 
+                    <td className="px-4 py-3 flex gap-2">
+                      <button
+                        className="p-1 text-gray-300 hover:text-blue-500 transition-colors"
+                        onClick={() => editarOperador(operador.id)}
+                      >
+                        <Pencil size={16} />
+                      </button>
+                      <button
                         className="p-1 text-gray-300 hover:text-red-500 transition-colors"
                         onClick={() => confirmarExclusao(operador.id)}
                         disabled={operador.situacao === 'DESATIVADO'}

--- a/frontend/pages/produtos.tsx
+++ b/frontend/pages/produtos.tsx
@@ -5,7 +5,7 @@ import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { PageLoader } from '@/components/ui/PageLoader';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
-import { AlertCircle, Plus, Search, Trash2 } from 'lucide-react';
+import { AlertCircle, Plus, Search, Trash2, Pencil } from 'lucide-react';
 import api from '@/lib/api';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -254,10 +254,15 @@ export default function ProdutosPage() {
                 {produtosFiltrados.map((produto) => (
                   <tr
                     key={produto.id}
-                    className="border-b border-gray-700 hover:bg-[#1a1f2b] cursor-pointer transition-colors"
-                    onClick={() => editarProduto(produto.id)}
+                    className="border-b border-gray-700 hover:bg-[#1a1f2b] transition-colors"
                   >
-                    <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                    <td className="px-4 py-3 flex gap-2">
+                      <button
+                        className="p-1 text-gray-300 hover:text-blue-500 transition-colors"
+                        onClick={() => editarProduto(produto.id)}
+                      >
+                        <Pencil size={16} />
+                      </button>
                       <button
                         className="p-1 text-gray-300 hover:text-red-500 transition-colors"
                         onClick={() => confirmarExclusao(produto.id)}


### PR DESCRIPTION
## Resumo
- substituir clique na linha por botão de lápis para editar catálogos
- aplicar mesmo comportamento às listagens de operadores estrangeiros e produtos

## Testes
- `npm test` (falhou: Environment variable not found: DATABASE_URL)
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_6893545dfad48330938b1c8643e9c6c0