### PR TITLE
Adicionar visualização de produtos em catálogos

### DIFF
--- a/backend/src/controllers/produto.controller.ts
+++ b/backend/src/controllers/produto.controller.ts
@@ -21,7 +21,10 @@ export async function listarProdutos(req: Request, res: Response) {
         | 'ATIVADO'
         | 'DESATIVADO'
         | undefined,
-      ncm: req.query.ncm as string | undefined
+      ncm: req.query.ncm as string | undefined,
+      catalogoId: req.query.catalogoId
+        ? Number(req.query.catalogoId)
+        : undefined
     };
     const produtos = await produtoService.listarTodos(filtros);
     res.json(produtos);

--- a/backend/src/services/produto.service.ts
+++ b/backend/src/services/produto.service.ts
@@ -41,6 +41,7 @@ export interface ListarProdutosFiltro {
   status?: 'PENDENTE' | 'APROVADO' | 'PROCESSANDO' | 'TRANSMITIDO' | 'ERRO';
   situacao?: 'RASCUNHO' | 'ATIVADO' | 'DESATIVADO';
   ncm?: string;
+  catalogoId?: number;
 }
 
 export class ProdutoService {
@@ -50,6 +51,7 @@ export class ProdutoService {
     if (filtros.status) where.status = filtros.status;
     if (filtros.ncm) where.ncmCodigo = filtros.ncm;
     if (filtros.situacao) where.situacao = filtros.situacao;
+    if (filtros.catalogoId) where.catalogoId = filtros.catalogoId;
 
     const produtos = await catalogoPrisma.produto.findMany({
       where,


### PR DESCRIPTION
## Resumo
- permitir filtro por catálogo na listagem de produtos da API
- incluir botão de visualização na lista de catálogos
- exibir modal com detalhes do catálogo e produtos vinculados

## Testes
- `npm test` *(falhou: Environment variable not found: DATABASE_URL)*
- `DATABASE_URL="mysql://user:pass@localhost:3306/db" npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_689563dc08648330b3b82359565c5cb0