### PR TITLE
Lista códigos internos e evita duplicidades

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -229,6 +229,7 @@ model CodigoInternoProduto {
   codigo    String  @map("codigo")
   produto   Produto @relation(fields: [produtoId], references: [id], onDelete: Cascade)
 
+  @@unique([produtoId, codigo], name: "uk_produto_codigo")
   @@map("codigo_interno_produto")
 }
 

--- a/backend/src/controllers/catalogo.controller.ts
+++ b/backend/src/controllers/catalogo.controller.ts
@@ -50,9 +50,11 @@ export async function criarCatalogo(req: Request, res: Response) {
     const catalogo = await catalogoService.criar(req.body);
     return res.status(201).json(catalogo);
   } catch (error: unknown) {
-    return res.status(500).json({ 
-      error: error instanceof Error ? error.message : 'Erro ao criar catálogo' 
-    });
+    const message = error instanceof Error ? error.message : 'Erro ao criar catálogo';
+    if (message.includes('Já existe um catálogo')) {
+      return res.status(400).json({ error: message });
+    }
+    return res.status(500).json({ error: message });
   }
 }
 
@@ -67,13 +69,13 @@ export async function atualizarCatalogo(req: Request, res: Response) {
     const catalogo = await catalogoService.atualizar(Number(id), req.body);
     return res.status(200).json(catalogo);
   } catch (error: unknown) {
-    // Verifica se é erro de "não encontrado" pela mensagem
     const errorMessage = error instanceof Error ? error.message : `Erro ao atualizar catálogo ID ${id}`;
-    
+    if (errorMessage.includes('Já existe um catálogo')) {
+      return res.status(400).json({ error: errorMessage });
+    }
     if (errorMessage.includes('não encontrado')) {
       return res.status(404).json({ error: errorMessage });
     }
-    
     return res.status(500).json({ error: errorMessage });
   }
 }

--- a/backend/src/validators/produto.validator.ts
+++ b/backend/src/validators/produto.validator.ts
@@ -9,7 +9,12 @@ export const createProdutoSchema = z.object({
   denominacao: z.string().max(100).min(1),
   descricao: z.string().min(1),
   valoresAtributos: z.record(z.any()).optional(),
-  codigosInternos: z.array(z.string().max(50)).optional(),
+  codigosInternos: z
+    .array(z.string().max(50))
+    .optional()
+    .refine(arr => !arr || new Set(arr).size === arr.length, {
+      message: 'Códigos internos duplicados não são permitidos'
+    }),
   operadoresEstrangeiros: z.array(z.object({
     paisCodigo: z.string().min(2),
     conhecido: z.boolean(),
@@ -28,7 +33,12 @@ export const updateProdutoSchema = z.object({
   denominacao: z.string().max(100).optional(),
   descricao: z.string().optional(),
   valoresAtributos: z.record(z.any()).optional(),
-  codigosInternos: z.array(z.string().max(50)).optional(),
+  codigosInternos: z
+    .array(z.string().max(50))
+    .optional()
+    .refine(arr => !arr || new Set(arr).size === arr.length, {
+      message: 'Códigos internos duplicados não são permitidos'
+    }),
   operadoresEstrangeiros: z.array(z.object({
     paisCodigo: z.string().min(2),
     conhecido: z.boolean(),

--- a/frontend/pages/produtos.tsx
+++ b/frontend/pages/produtos.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button';
 import { PageLoader } from '@/components/ui/PageLoader';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { AlertCircle, Plus, Search, Trash2, Pencil } from 'lucide-react';
+import { Hint } from '@/components/ui/Hint';
 import api from '@/lib/api';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -22,7 +23,7 @@ interface Produto {
   catalogoCpfCnpj?: string;
   denominacao?: string;
   descricao?: string;
-  codigoInterno?: string;
+  codigosInternos?: string[];
   situacao?: string;
 }
 
@@ -123,7 +124,7 @@ export default function ProdutosPage() {
     const termo = busca.toLowerCase();
     const matchBusca =
       (p.denominacao && p.denominacao.toLowerCase().includes(termo)) ||
-      (p.codigoInterno && p.codigoInterno.toLowerCase().includes(termo));
+      (p.codigosInternos && p.codigosInternos.some(c => c.toLowerCase().includes(termo)));
 
     const matchStatus =
       filtros.status === 'TODOS' || p.status === filtros.status;
@@ -293,7 +294,20 @@ export default function ProdutosPage() {
                     </td>
                     <td className="px-4 py-3">{produto.catalogoNome ?? '-'}</td>
                     <td className="px-4 py-3">{produto.denominacao ?? produto.codigo ?? '-'}</td>
-                    <td className="px-4 py-3">{produto.codigoInterno ?? '-'}</td>
+                    <td className="px-4 py-3">
+                      {produto.codigosInternos && produto.codigosInternos.length > 0 ? (
+                        <div className="flex items-center gap-1">
+                          <span className="truncate max-w-[150px]">
+                            {produto.codigosInternos.join(', ')}
+                          </span>
+                          {produto.codigosInternos.join(', ').length > 20 && (
+                            <Hint text={produto.codigosInternos.join(', ')} />
+                          )}
+                        </div>
+                      ) : (
+                        '-'
+                      )}
+                    </td>
                     <td className="px-4 py-3">-</td>
                     <td className="px-4 py-3">
                       <span

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -182,8 +182,13 @@ export default function ProdutoPage() {
   }
 
   function adicionarCodigoInterno() {
-    if (!novoCodigoInterno.trim()) return;
-    setCodigosInternos(prev => [...prev, novoCodigoInterno.trim()]);
+    const codigo = novoCodigoInterno.trim();
+    if (!codigo) return;
+    if (codigosInternos.some(c => c.toLowerCase() === codigo.toLowerCase())) {
+      addToast('Código interno já incluído', 'error');
+      return;
+    }
+    setCodigosInternos(prev => [...prev, codigo]);
     setNovoCodigoInterno('');
   }
 


### PR DESCRIPTION
## Resumo
- impede códigos internos duplicados no cadastro de produtos
- exibe todos os códigos internos na listagem com tooltip
- valida nome único ao criar ou atualizar catálogos

## Testes
- `npm --prefix backend test` *(falhou: Can't reach database server at `localhost:3306`)*
- `DATABASE_URL="mysql://user:pass@localhost:3306/db" npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_689aa5f56a548330b2ef00185c89abcf