### PR TITLE
Exibe modalidade com nomes amigáveis

### DIFF
--- a/frontend/pages/produtos.tsx
+++ b/frontend/pages/produtos.tsx
@@ -25,6 +25,7 @@ interface Produto {
   descricao?: string;
   codigosInternos?: string[];
   situacao?: string;
+  modalidade?: 'IMPORTACAO' | 'EXPORTACAO';
 }
 
 export default function ProdutosPage() {
@@ -117,6 +118,17 @@ export default function ProdutosPage() {
         return 'bg-[#e4a8351a] text-[#e4a835] border border-[#e4a835]';
       default:
         return 'bg-gray-900/50 text-gray-400 border border-gray-700';
+    }
+  }
+
+  function getModalidadeLabel(modalidade: string) {
+    switch (modalidade) {
+      case 'IMPORTACAO':
+        return 'Importação';
+      case 'EXPORTACAO':
+        return 'Exportação';
+      default:
+        return modalidade;
     }
   }
 
@@ -308,7 +320,11 @@ export default function ProdutosPage() {
                         '-'
                       )}
                     </td>
-                    <td className="px-4 py-3">-</td>
+                    <td className="px-4 py-3">
+                      {produto.modalidade
+                        ? getModalidadeLabel(produto.modalidade)
+                        : '-'}
+                    </td>
                     <td className="px-4 py-3">
                       <span
                         className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusClasses(

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -601,8 +601,8 @@ export default function ProdutoPage() {
           <Select
             label="Modalidade"
             options={[
-              { value: 'IMPORTACAO', label: 'IMPORTACAO' },
-              { value: 'EXPORTACAO', label: 'EXPORTACAO' }
+              { value: 'IMPORTACAO', label: 'Importação' },
+              { value: 'EXPORTACAO', label: 'Exportação' }
             ]}
             value={modalidade}
             onChange={e => setModalidade(e.target.value)}


### PR DESCRIPTION
## Resumo
- Adiciona rótulos "Importação" e "Exportação" no formulário de produtos
- Exibe a modalidade com nomenclatura amigável na listagem de produtos

## Testes
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ab52f1a188330a8ea525e329c02c6