### PR TITLE
Adicionar listagem de produtos no painel

### DIFF
--- a/frontend/components/dashboard/ListaProdutosPainel.tsx
+++ b/frontend/components/dashboard/ListaProdutosPainel.tsx
@@ -1,0 +1,310 @@
+import React, { useEffect, useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { Hint } from '@/components/ui/Hint';
+import { Search, Pencil, Trash2 } from 'lucide-react';
+import api from '@/lib/api';
+import { useRouter } from 'next/router';
+import { useToast } from '@/components/ui/ToastContext';
+
+interface Produto {
+  id: number;
+  codigo: string;
+  ncmCodigo: string;
+  status: 'PENDENTE' | 'APROVADO' | 'PROCESSANDO' | 'TRANSMITIDO' | 'ERRO';
+  atualizadoEm: string;
+  catalogoNumero?: number;
+  catalogoNome?: string;
+  catalogoCpfCnpj?: string;
+  denominacao?: string;
+  descricao?: string;
+  codigosInternos?: string[];
+  situacao?: string;
+  modalidade?: 'IMPORTACAO' | 'EXPORTACAO';
+}
+
+export function ListaProdutosPainel() {
+  const [produtos, setProdutos] = useState<Produto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busca, setBusca] = useState('');
+  const [filtros, setFiltros] = useState({
+    status: 'TODOS',
+    situacao: 'TODOS'
+  });
+  const [produtoParaExcluir, setProdutoParaExcluir] = useState<number | null>(null);
+  const router = useRouter();
+  const { addToast } = useToast();
+
+  useEffect(() => {
+    carregarProdutos();
+  }, []);
+
+  async function carregarProdutos() {
+    try {
+      setLoading(true);
+      const response = await api.get('/produtos');
+      setProdutos(response.data);
+      setError(null);
+    } catch (err) {
+      console.error('Erro ao carregar produtos:', err);
+      setError('Não foi possível carregar os produtos.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function formatarData(dataString: string) {
+    const data = new Date(dataString);
+    return data.toLocaleDateString('pt-BR') + ' ' + data.toLocaleTimeString('pt-BR');
+  }
+
+  function getStatusClasses(status: string) {
+    switch (status) {
+      case 'PENDENTE':
+        return 'bg-[#e4a8351a] text-[#e4a835] border border-[#e4a835]';
+      case 'APROVADO':
+        return 'bg-[#27f58a1a] text-[#27f58a] border border-[#27f58a]';
+      case 'PROCESSANDO':
+        return 'bg-[#4c82d31a] text-[#4c82d3] border border-[#4c82d3]';
+      case 'TRANSMITIDO':
+        return 'bg-[#4c82d31a] text-[#4c82d3] border border-[#4c82d3]';
+      case 'ERRO':
+        return 'bg-[#f2545f1a] text-[#f2545f] border border-[#f2545f]';
+      default:
+        return 'bg-gray-900/50 text-gray-400 border border-gray-700';
+    }
+  }
+
+  function getSituacaoClasses(situacao?: string) {
+    switch (situacao) {
+      case 'ATIVADO':
+        return 'bg-[#27f58a1a] text-[#27f58a] border border-[#27f58a]';
+      case 'DESATIVADO':
+        return 'bg-[#f2545f1a] text-[#f2545f] border border-[#f2545f]';
+      case 'RASCUNHO':
+        return 'bg-[#e4a8351a] text-[#e4a835] border border-[#e4a835]';
+      default:
+        return 'bg-gray-900/50 text-gray-400 border border-gray-700';
+    }
+  }
+
+  function getModalidadeLabel(modalidade: string) {
+    switch (modalidade) {
+      case 'IMPORTACAO':
+        return 'Importação';
+      case 'EXPORTACAO':
+        return 'Exportação';
+      default:
+        return modalidade;
+    }
+  }
+
+  const produtosFiltrados = produtos.filter(p => {
+    const termo = busca.toLowerCase();
+    const matchBusca =
+      (p.denominacao && p.denominacao.toLowerCase().includes(termo)) ||
+      (p.catalogoNome && p.catalogoNome.toLowerCase().includes(termo)) ||
+      (p.ncmCodigo && p.ncmCodigo.toLowerCase().includes(termo));
+
+    const matchStatus = filtros.status === 'TODOS' || p.status === filtros.status;
+    const matchSituacao = filtros.situacao === 'TODOS' || p.situacao === filtros.situacao;
+
+    return matchBusca && matchStatus && matchSituacao;
+  });
+
+  function editarProduto(id: number) {
+    router.push(`/produtos/${id}`);
+  }
+
+  function confirmarExclusao(id: number) {
+    setProdutoParaExcluir(id);
+  }
+
+  function cancelarExclusao() {
+    setProdutoParaExcluir(null);
+  }
+
+  async function excluirProduto() {
+    if (!produtoParaExcluir) return;
+    try {
+      await api.delete(`/produtos/${produtoParaExcluir}`);
+      setProdutos(produtos.filter(p => p.id !== produtoParaExcluir));
+      addToast('Produto excluído com sucesso', 'success');
+    } catch (err) {
+      console.error('Erro ao excluir produto:', err);
+      addToast('Erro ao excluir produto', 'error');
+    } finally {
+      setProdutoParaExcluir(null);
+    }
+  }
+
+  return (
+    <>
+      <Card className="mb-6">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <div className="relative md:col-span-2">
+            <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+              <Search size={18} className="text-gray-400" />
+            </div>
+            <input
+              type="text"
+              placeholder="Buscar produto..."
+              className="pl-10 pr-4 py-2 w-full bg-[#1e2126] border border-gray-700 text-white rounded-lg focus:outline-none focus:ring focus:border-blue-500"
+              value={busca}
+              onChange={e => setBusca(e.target.value)}
+            />
+          </div>
+          <select
+            className="bg-[#1e2126] border border-gray-700 text-white rounded-lg px-3 py-2 focus:outline-none focus:ring focus:border-blue-500"
+            value={filtros.status}
+            onChange={e => setFiltros({ ...filtros, status: e.target.value })}
+          >
+            <option value="TODOS">Todos os status</option>
+            <option value="PENDENTE">Pendente</option>
+            <option value="APROVADO">Aprovado</option>
+            <option value="PROCESSANDO">Processando</option>
+            <option value="TRANSMITIDO">Transmitido</option>
+            <option value="ERRO">Erro</option>
+          </select>
+          <select
+            className="bg-[#1e2126] border border-gray-700 text-white rounded-lg px-3 py-2 focus:outline-none focus:ring focus:border-blue-500"
+            value={filtros.situacao}
+            onChange={e => setFiltros({ ...filtros, situacao: e.target.value })}
+          >
+            <option value="TODOS">Todas as situações</option>
+            <option value="ATIVADO">Ativado</option>
+            <option value="DESATIVADO">Desativado</option>
+            <option value="RASCUNHO">Rascunho</option>
+          </select>
+          <div className="text-sm text-gray-400 self-center">
+            Exibindo {produtosFiltrados.length} de {produtos.length} produtos
+          </div>
+        </div>
+      </Card>
+
+      {error && (
+        <div className="bg-red-500/20 border border-red-700 p-4 rounded-lg mb-6 flex items-center gap-3">
+          <span>{error}</span>
+        </div>
+      )}
+
+      <Card>
+        {loading ? (
+          <div className="text-center py-10">
+            <p className="text-gray-400">Carregando produtos...</p>
+          </div>
+        ) : produtosFiltrados.length === 0 ? (
+          <div className="text-center py-10">
+            <p className="text-gray-400 mb-4">Nenhum produto encontrado.</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm text-left">
+              <thead className="text-gray-400 bg-[#0f1419] uppercase text-xs">
+                <tr>
+                  <th className="w-16 px-4 py-3 text-center">Ações</th>
+                  <th className="px-4 py-3">Catálogo</th>
+                  <th className="px-4 py-3">Nome</th>
+                  <th className="px-4 py-3">Cód. Int. (SKU/PN)</th>
+                  <th className="px-4 py-3">Modalidade</th>
+                  <th className="px-4 py-3">Status</th>
+                  <th className="px-4 py-3">Situação</th>
+                  <th className="px-4 py-3">Última Alteração</th>
+                </tr>
+              </thead>
+              <tbody>
+                {produtosFiltrados.map((produto) => (
+                  <tr
+                    key={produto.id}
+                    className="border-b border-gray-700 hover:bg-[#1a1f2b] transition-colors"
+                  >
+                    <td className="px-4 py-3 flex gap-2">
+                      <button
+                        className="p-1 text-gray-300 hover:text-blue-500 transition-colors"
+                        onClick={() => editarProduto(produto.id)}
+                        title="Editar produto"
+                      >
+                        <Pencil size={16} />
+                      </button>
+                      <button
+                        className="p-1 text-gray-300 hover:text-red-500 transition-colors"
+                        onClick={() => confirmarExclusao(produto.id)}
+                        title="Excluir produto"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </td>
+                    <td className="px-4 py-3">{produto.catalogoNome ?? '-'}</td>
+                    <td className="px-4 py-3">{produto.denominacao ?? produto.codigo ?? '-'}</td>
+                    <td className="px-4 py-3">
+                      {produto.codigosInternos && produto.codigosInternos.length > 0 ? (
+                        <div className="flex items-center gap-1">
+                          <span className="truncate max-w-[150px]">
+                            {produto.codigosInternos.join(', ')}
+                          </span>
+                          {produto.codigosInternos.join(', ').length > 20 && (
+                            <Hint text={produto.codigosInternos.join(', ')} />
+                          )}
+                        </div>
+                      ) : (
+                        '-'
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      {produto.modalidade ? getModalidadeLabel(produto.modalidade) : '-'}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusClasses(
+                          produto.status
+                        )}`}
+                      >
+                        {produto.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      {produto.situacao ? (
+                        <span
+                          className={`px-2 py-1 rounded-full text-xs font-medium ${getSituacaoClasses(
+                            produto.situacao
+                          )}`}
+                        >
+                          {produto.situacao}
+                        </span>
+                      ) : (
+                        '-'
+                      )}
+                    </td>
+                    <td className="px-4 py-3">{formatarData(produto.atualizadoEm)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+
+      {produtoParaExcluir && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-[#151921] rounded-lg max-w-md w-full p-6 border border-gray-700">
+            <h3 className="text-xl font-semibold text-white mb-4">Confirmar Exclusão</h3>
+            <p className="text-gray-300 mb-6">
+              Tem certeza que deseja excluir este produto? Esta ação não pode ser desfeita.
+            </p>
+            <div className="flex justify-end gap-3">
+              <Button variant="outline" onClick={cancelarExclusao}>
+                Cancelar
+              </Button>
+              <Button variant="danger" onClick={excluirProduto}>
+                Excluir
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default ListaProdutosPainel;

--- a/frontend/pages/painel.tsx
+++ b/frontend/pages/painel.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Card } from '@/components/ui/Card';
 import api from '@/lib/api';
+import { ListaProdutosPainel } from '@/components/dashboard/ListaProdutosPainel';
 
 interface ResumoDashboard {
   catalogos: {
@@ -38,26 +39,30 @@ export default function PainelPage() {
       {loading ? (
         <p className="text-gray-400">Carregando...</p>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <Card headerTitle="Produtos">
-            <p className="text-4xl font-bold text-white mb-4">
-              {resumo?.produtos.total ?? 0}
-            </p>
-            <ul className="text-sm text-gray-300 space-y-1">
-              <li>PENDENTE: {resumo?.produtos.porStatus.PENDENTE ?? 0}</li>
-              <li>APROVADO: {resumo?.produtos.porStatus.APROVADO ?? 0}</li>
-              <li>PROCESSANDO: {resumo?.produtos.porStatus.PROCESSANDO ?? 0}</li>
-              <li>TRANSMITIDO: {resumo?.produtos.porStatus.TRANSMITIDO ?? 0}</li>
-              <li>ERRO: {resumo?.produtos.porStatus.ERRO ?? 0}</li>
-            </ul>
-          </Card>
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+            <Card headerTitle="Produtos">
+              <p className="text-4xl font-bold text-white mb-4">
+                {resumo?.produtos.total ?? 0}
+              </p>
+              <ul className="text-sm text-gray-300 space-y-1">
+                <li>PENDENTE: {resumo?.produtos.porStatus.PENDENTE ?? 0}</li>
+                <li>APROVADO: {resumo?.produtos.porStatus.APROVADO ?? 0}</li>
+                <li>PROCESSANDO: {resumo?.produtos.porStatus.PROCESSANDO ?? 0}</li>
+                <li>TRANSMITIDO: {resumo?.produtos.porStatus.TRANSMITIDO ?? 0}</li>
+                <li>ERRO: {resumo?.produtos.porStatus.ERRO ?? 0}</li>
+              </ul>
+            </Card>
 
-          <Card headerTitle="Catálogos">
-            <p className="text-4xl font-bold text-white">
-              {resumo?.catalogos.total ?? 0}
-            </p>
-          </Card>
-        </div>
+            <Card headerTitle="Catálogos">
+              <p className="text-4xl font-bold text-white">
+                {resumo?.catalogos.total ?? 0}
+              </p>
+            </Card>
+          </div>
+
+          <ListaProdutosPainel />
+        </>
       )}
     </DashboardLayout>
   );


### PR DESCRIPTION
## Resumo
- exibe listagem de produtos no painel com busca e filtros
- permite filtragem por nome, catálogo, NCM, status e situação

## Testes
- `npm build` (falhou: Unknown command "build")
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_689ac3bae4508330989a7d9085dfe5d5