### PR TITLE
Destaca listagem de produtos do painel

### DIFF
--- a/frontend/pages/painel.tsx
+++ b/frontend/pages/painel.tsx
@@ -61,7 +61,9 @@ export default function PainelPage() {
             </Card>
           </div>
 
-          <ListaProdutosPainel />
+          <section className="mt-8 bg-[#151921] p-6 rounded-lg border border-gray-700">
+            <ListaProdutosPainel />
+          </section>
         </>
       )}
     </DashboardLayout>


### PR DESCRIPTION
## Resumo
- Isola a listagem de produtos do painel em um container próprio para dar destaque

## Testes
- `npm run build:all`
- `cd backend && npm test` *(falhou: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_689ac905abec8330a5136bb3409a338c