### PR TITLE
Corrige filtro de catálogo na listagem de produtos

### DIFF
--- a/frontend/pages/produtos.tsx
+++ b/frontend/pages/produtos.tsx
@@ -44,12 +44,6 @@ export default function ProdutosPage() {
   const { addToast } = useToast();
 
   useEffect(() => {
-    if (router.isReady && typeof router.query.catalogoId === 'string') {
-      setFiltros(prev => ({ ...prev, catalogoId: router.query.catalogoId as string }));
-    }
-  }, [router.isReady, router.query.catalogoId]);
-
-  useEffect(() => {
     async function carregarCatalogos() {
       try {
         const response = await api.get('/catalogos');
@@ -63,8 +57,17 @@ export default function ProdutosPage() {
 
   useEffect(() => {
     if (!router.isReady) return;
+
+    const catalogoIdFromQuery =
+      typeof router.query.catalogoId === 'string' ? router.query.catalogoId : '';
+
+    if (catalogoIdFromQuery && filtros.catalogoId !== catalogoIdFromQuery) {
+      setFiltros(prev => ({ ...prev, catalogoId: catalogoIdFromQuery }));
+      return;
+    }
+
     carregarProdutos();
-  }, [router.isReady, filtros.status, filtros.situacao, filtros.catalogoId]);
+  }, [router.isReady, router.query.catalogoId, filtros.status, filtros.situacao, filtros.catalogoId]);
 
   async function carregarProdutos() {
     try {


### PR DESCRIPTION
## Resumo
- impede requisição sem filtro ao carregar produtos a partir de um catálogo

## Testes
- `npm test` (frontend) *falhou: Missing script: "test"*
- `npm run build` (frontend)
- `npm test` (backend) *falhou: Environment variable not found: DATABASE_URL*
- `npm run build` (backend)`

------
https://chatgpt.com/codex/tasks/task_e_689b213c4b5c8330ae379a9d2f64a084