### PR TITLE
Corrige reaplicação do filtro de catálogo na listagem de produtos

### DIFF
--- a/frontend/pages/produtos.tsx
+++ b/frontend/pages/produtos.tsx
@@ -63,6 +63,13 @@ export default function ProdutosPage() {
 
     if (catalogoIdFromQuery && filtros.catalogoId !== catalogoIdFromQuery) {
       setFiltros(prev => ({ ...prev, catalogoId: catalogoIdFromQuery }));
+
+      // remove o parâmetro da URL após aplicar o filtro para evitar que
+      // o catálogo seja reatribuído ao alterar o filtro manualmente
+      const { catalogoId, ...rest } = router.query;
+      router.replace({ pathname: router.pathname, query: rest }, undefined, {
+        shallow: true,
+      });
       return;
     }
 


### PR DESCRIPTION
## Resumo
- remove o parâmetro `catalogoId` da URL após uso inicial
- evita que o filtro seja reatribuído ao alterar manualmente o catálogo

## Testes
- `npm run build:all`
- `npm test` *(erro de script ausente)*

------
https://chatgpt.com/codex/tasks/task_e_689b23d97088833088dcf5ae9dc3e41f