### PR TITLE
Restringe operadores estrangeiros ao superusuário

### DIFF
--- a/backend/prisma/migrations/20250101120000_add_super_user_id_to_operador_estrangeiro/migration.sql
+++ b/backend/prisma/migrations/20250101120000_add_super_user_id_to_operador_estrangeiro/migration.sql
@@ -1,0 +1,10 @@
+ALTER TABLE `operador_estrangeiro`
+  ADD COLUMN `super_user_id` INT NOT NULL,
+  ADD INDEX `idx_super_user_id` (`super_user_id`),
+  ADD CONSTRAINT `operador_estrangeiro_super_user_id_fkey` FOREIGN KEY (`super_user_id`) REFERENCES `comex`(`idv32`);
+
+-- Preenche super_user_id utilizando o CNPJ raiz do catálogo vinculado
+UPDATE operador_estrangeiro oe
+JOIN catalogo c ON SUBSTRING(c.cpf_cnpj,1,8) = oe.cnpj_raiz_responsavel
+SET oe.super_user_id = c.super_user_id
+WHERE oe.super_user_id IS NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   name      String   @map("nomecompleto")
 
   subUsuarios SubUsuario[]
+  operadoresEstrangeiros OperadorEstrangeiro[]
 
   @@map("comex")
 }
@@ -100,6 +101,9 @@ model Subdivisao {
 model OperadorEstrangeiro {
   id                     Int      @id @default(autoincrement()) @map("id")
   cnpjRaizResponsavel    String   @map("cnpj_raiz_responsavel")
+  superUserId            Int      @map("super_user_id")
+
+  superUser              User     @relation(fields: [superUserId], references: [id])
   
   // Dados básicos
   paisCodigo             String   @map("pais_codigo")
@@ -127,7 +131,8 @@ model OperadorEstrangeiro {
   subdivisao             Subdivisao? @relation(fields: [subdivisaoCodigo], references: [codigo])
   identificacoesAdicionais IdentificacaoAdicional[]
   operadorEstrangeiroProdutos OperadorEstrangeiroProduto[] @relation("OperadorProduto")
-  
+
+  @@index([superUserId], name: "idx_super_user_id")
   @@map("operador_estrangeiro")
 }
 

--- a/backend/src/controllers/operador-estrangeiro.controller.ts
+++ b/backend/src/controllers/operador-estrangeiro.controller.ts
@@ -12,7 +12,7 @@ const operadorEstrangeiroService = new OperadorEstrangeiroService();
 export async function listarOperadoresEstrangeiros(req: Request, res: Response) {
   try {
     const cnpjRaiz = req.query.cnpjRaiz as string;
-    const operadores = await operadorEstrangeiroService.listarTodos(cnpjRaiz);
+    const operadores = await operadorEstrangeiroService.listarTodos(cnpjRaiz, req.user!.superUserId);
     return res.status(200).json(operadores);
   } catch (error: unknown) {
     logger.error('Erro ao listar operadores estrangeiros:', error);
@@ -28,9 +28,9 @@ export async function listarOperadoresEstrangeiros(req: Request, res: Response) 
  */
 export async function obterOperadorEstrangeiro(req: Request, res: Response) {
   const { id } = req.params;
-  
+
   try {
-    const operador = await operadorEstrangeiroService.buscarPorId(Number(id));
+    const operador = await operadorEstrangeiroService.buscarPorId(Number(id), req.user!.superUserId);
     
     if (!operador) {
       return res.status(404).json({ error: 'Operador estrangeiro não encontrado' });
@@ -51,9 +51,9 @@ export async function obterOperadorEstrangeiro(req: Request, res: Response) {
  */
 export async function buscarPorTin(req: Request, res: Response) {
   const { tin } = req.params;
-  
+
   try {
-    const operadores = await operadorEstrangeiroService.buscarPorTin(tin);
+    const operadores = await operadorEstrangeiroService.buscarPorTin(tin, req.user!.superUserId);
     return res.status(200).json(operadores);
   } catch (error: unknown) {
     logger.error(`Erro ao buscar operadores por TIN ${tin}:`, error);
@@ -69,7 +69,7 @@ export async function buscarPorTin(req: Request, res: Response) {
  */
 export async function criarOperadorEstrangeiro(req: Request, res: Response) {
   try {
-    const operador = await operadorEstrangeiroService.criar(req.body);
+    const operador = await operadorEstrangeiroService.criar({ ...req.body, superUserId: req.user!.superUserId });
     return res.status(201).json(operador);
   } catch (error: unknown) {
     logger.error('Erro ao criar operador estrangeiro:', error);
@@ -85,9 +85,9 @@ export async function criarOperadorEstrangeiro(req: Request, res: Response) {
  */
 export async function atualizarOperadorEstrangeiro(req: Request, res: Response) {
   const { id } = req.params;
-  
+
   try {
-    const operador = await operadorEstrangeiroService.atualizar(Number(id), req.body);
+    const operador = await operadorEstrangeiroService.atualizar(Number(id), { ...req.body, superUserId: req.user!.superUserId });
     return res.status(200).json(operador);
   } catch (error: unknown) {
     logger.error(`Erro ao atualizar operador estrangeiro ID ${id}:`, error);
@@ -108,9 +108,9 @@ export async function atualizarOperadorEstrangeiro(req: Request, res: Response) 
  */
 export async function removerOperadorEstrangeiro(req: Request, res: Response) {
   const { id } = req.params;
-  
+
   try {
-    await operadorEstrangeiroService.remover(Number(id));
+    await operadorEstrangeiroService.remover(Number(id), req.user!.superUserId);
     return res.status(204).send();
   } catch (error: unknown) {
     logger.error(`Erro ao remover operador estrangeiro ID ${id}:`, error);
@@ -186,7 +186,7 @@ export async function listarSubdivisoes(req: Request, res: Response) {
  */
 export async function listarCnpjsCatalogos(req: Request, res: Response) {
   try {
-    const cnpjs = await operadorEstrangeiroService.listarCnpjsCatalogos();
+    const cnpjs = await operadorEstrangeiroService.listarCnpjsCatalogos(req.user!.superUserId);
     return res.status(200).json(cnpjs);
   } catch (error: unknown) {
     logger.error('Erro ao listar CNPJs dos catálogos:', error);

--- a/backend/src/middlewares/auth.middleware.ts
+++ b/backend/src/middlewares/auth.middleware.ts
@@ -1,6 +1,7 @@
 // src/middlewares/auth.middleware.ts
 import { Request, Response, NextFunction } from 'express';
 import { verifyToken } from '../utils/jwt';
+import { AuthUser } from '../interfaces/auth-user';
 
 export function authMiddleware(req: Request, res: Response, next: NextFunction) {
   const authHeader = req.headers.authorization;
@@ -18,7 +19,10 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction) 
     return res.status(401).json({ error: 'Token mal formatado' });
 
   try {
-    const decoded = verifyToken(token);
+    const decoded = verifyToken(token) as AuthUser;
+    if (!decoded.superUserId) {
+      return res.status(401).json({ error: 'Identificador do superusuário ausente' });
+    }
     req.user = decoded;
     next();
   } catch (error) {

--- a/backend/src/routes/operador-estrangeiro.routes.ts
+++ b/backend/src/routes/operador-estrangeiro.routes.ts
@@ -20,7 +20,12 @@ import { createOperadorEstrangeiroSchema, updateOperadorEstrangeiroSchema } from
 const router = Router();
 
 // Todas as rotas protegidas por autenticação
-router.use(authMiddleware);
+router.use(authMiddleware, (req, res, next) => {
+  if (!req.user?.superUserId) {
+    return res.status(401).json({ error: 'Identificador do superusuário ausente' });
+  }
+  next();
+});
 
 // ========== ROTAS AUXILIARES (devem vir ANTES das rotas principais) ==========
 router.get('/aux/paises', listarPaises);

--- a/backend/src/services/__tests__/operador-estrangeiro.service.test.ts
+++ b/backend/src/services/__tests__/operador-estrangeiro.service.test.ts
@@ -1,0 +1,55 @@
+import { OperadorEstrangeiroService } from '../operador-estrangeiro.service'
+import { catalogoPrisma } from '../../utils/prisma'
+import { OperadorEstrangeiroStatus } from '@prisma/client'
+
+jest.mock('../../utils/prisma', () => ({
+  catalogoPrisma: {
+    operadorEstrangeiro: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn()
+    },
+    catalogo: {
+      findMany: jest.fn()
+    }
+  }
+}))
+
+describe('OperadorEstrangeiroService - superUserId', () => {
+  const service = new OperadorEstrangeiroService()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('filtra por superUserId ao listar', async () => {
+    ;(catalogoPrisma.operadorEstrangeiro.findMany as jest.Mock).mockResolvedValue([])
+    await service.listarTodos(undefined, 1)
+    expect(catalogoPrisma.operadorEstrangeiro.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { superUserId: 1 } })
+    )
+  })
+
+  it('inclui superUserId ao criar', async () => {
+    ;(catalogoPrisma.operadorEstrangeiro.create as jest.Mock).mockResolvedValue({})
+    await service.criar({
+      cnpjRaizResponsavel: '12345678000199',
+      paisCodigo: 'BR',
+      nome: 'Teste',
+      situacao: OperadorEstrangeiroStatus.ATIVO,
+      superUserId: 1
+    })
+    expect(catalogoPrisma.operadorEstrangeiro.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ superUserId: 1 }) })
+    )
+  })
+
+  it('usa superUserId ao remover', async () => {
+    ;(catalogoPrisma.operadorEstrangeiro.update as jest.Mock).mockResolvedValue({})
+    await service.remover(2, 1)
+    expect(catalogoPrisma.operadorEstrangeiro.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 2, superUserId: 1 } })
+    )
+  })
+})

--- a/docs/OPERADOR_ESTRANGEIRO.md
+++ b/docs/OPERADOR_ESTRANGEIRO.md
@@ -4,6 +4,8 @@
 
 O módulo **Operador Estrangeiro** permite o cadastro e gerenciamento de fabricantes/produtores estrangeiros conforme especificações do Portal Único Siscomex (PUCOMEX). Este módulo é essencial para operações de importação, permitindo a identificação precisa dos fabricantes dos produtos importados.
 
+Cada operador está associado a um superusuário por meio do campo `super_user_id`. Apenas o superusuário autenticado pode listar, criar, alterar ou remover seus próprios operadores.
+
 ## Funcionalidades
 
 ### ✅ Implementadas
@@ -29,6 +31,7 @@ O módulo **Operador Estrangeiro** permite o cadastro e gerenciamento de fabrica
 #### `operador_estrangeiro`
 - **id**: Identificador único interno
 - **cnpj_raiz_responsavel**: CNPJ da empresa brasileira responsável
+- **super_user_id**: Identificador do superusuário proprietário
 - **pais_codigo**: Referência para tabela `pais`
 - **tin**: Trader Identification Number (formato: BR12345678000101)
 - **nome**: Razão social do operador estrangeiro

--- a/scripts_banco_catalogo_produtos.sql
+++ b/scripts_banco_catalogo_produtos.sql
@@ -98,6 +98,7 @@ DELIMITER ;
     CREATE TABLE IF NOT EXISTS operador_estrangeiro (
         id INT UNSIGNED NOT NULL AUTO_INCREMENT,
         cnpj_raiz_responsavel VARCHAR(14) NOT NULL,
+        super_user_id INT UNSIGNED NOT NULL,
         
         -- Dados básicos
         pais_codigo VARCHAR(10) NOT NULL,
@@ -127,8 +128,14 @@ DELIMITER ;
         INDEX idx_tin (tin),
         INDEX idx_nome (nome),
         INDEX idx_situacao (situacao),
+        INDEX idx_super_user_id (super_user_id),
         UNIQUE INDEX idx_tin_unique (tin) -- TIN deve ser único quando preenchido
     );
+
+    -- Vincula operadores existentes ao super usuário de seus catálogos
+    UPDATE operador_estrangeiro oe
+    JOIN catalogo c ON SUBSTRING(c.cpf_cnpj,1,8) = oe.cnpj_raiz_responsavel
+    SET oe.super_user_id = c.super_user_id;
 
     -- Tabela para identificações adicionais (DUNS, LEI, etc.)
     CREATE TABLE IF NOT EXISTS identificacao_adicional (


### PR DESCRIPTION
## Resumo
- garante que cada operador estrangeiro esteja associado a um superusuário
- limita operações de CRUD ao superusuário autenticado
- documenta nova regra e ajusta scripts de banco e testes

## Testes
- `npm test` *(falhou: Environment variable not found: DATABASE_URL)*
- `npm run build` 
- `npm run build:all`

------
https://chatgpt.com/codex/tasks/task_e_68a01158bbcc83308025df2746a3654c