### PR TITLE
Melhorias na troca de catálogo de trabalho

### DIFF
--- a/frontend/components/catalogos/WorkingCatalogModal.tsx
+++ b/frontend/components/catalogos/WorkingCatalogModal.tsx
@@ -18,6 +18,7 @@ interface WorkingCatalogModalProps {
 export function WorkingCatalogModal({ isOpen, onClose }: WorkingCatalogModalProps) {
   const { workingCatalog, setWorkingCatalog } = useWorkingCatalog();
   const [catalogos, setCatalogos] = useState<CatalogoResumo[]>([]);
+  const [selectedId, setSelectedId] = useState<string>('');
 
   useEffect(() => {
     if (!isOpen) return;
@@ -30,7 +31,8 @@ export function WorkingCatalogModal({ isOpen, onClose }: WorkingCatalogModalProp
       }
     }
     carregar();
-  }, [isOpen]);
+    setSelectedId(workingCatalog ? String(workingCatalog.id) : '');
+  }, [isOpen, workingCatalog]);
 
   const selecionar = (cat: CatalogoResumo | null) => {
     const selected: WorkingCatalog | null = cat
@@ -40,38 +42,34 @@ export function WorkingCatalogModal({ isOpen, onClose }: WorkingCatalogModalProp
     onClose();
   };
 
+  const handleConfirm = () => {
+    const cat = selectedId ? catalogos.find(c => c.id === Number(selectedId)) || null : null;
+    selecionar(cat);
+  };
+
   if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-[#151921] rounded-lg p-6 border border-gray-700 w-full max-w-md">
+      <div className="bg-[#1e2126] rounded-lg p-6 border border-gray-700 w-full max-w-md text-gray-300">
         <h3 className="text-xl font-semibold text-white mb-4">Selecionar Catálogo</h3>
-        <ul className="max-h-60 overflow-y-auto mb-4">
-          <li className="mb-2">
-            <button
-              className={`w-full text-left px-3 py-2 rounded hover:bg-[#262b36] ${!workingCatalog ? 'bg-[#262b36]' : ''}`}
-              onClick={() => selecionar(null)}
-            >
-              Todos os catálogos
-            </button>
-          </li>
+        <select
+          className="w-full mb-4 px-3 py-2 bg-[#1e2126] border border-gray-700 rounded text-gray-100 focus:outline-none focus:ring focus:border-blue-500"
+          value={selectedId}
+          onChange={e => setSelectedId(e.target.value)}
+        >
+          <option value="">Todos os catálogos</option>
           {catalogos.map(cat => (
-            <li key={cat.id} className="mb-2">
-              <button
-                className={`w-full text-left px-3 py-2 rounded hover:bg-[#262b36] ${
-                  workingCatalog?.id === cat.id ? 'bg-[#262b36]' : ''
-                }`}
-                onClick={() => selecionar(cat)}
-              >
-                {cat.numero} - {cat.nome}
-              </button>
-            </li>
+            <option key={cat.id} value={cat.id}>
+              {cat.numero} - {cat.nome}
+            </option>
           ))}
-        </ul>
-        <div className="flex justify-end">
+        </select>
+        <div className="flex justify-end space-x-2">
           <Button variant="outline" onClick={onClose}>
-            Fechar
+            Cancelar
           </Button>
+          <Button onClick={handleConfirm}>Selecionar</Button>
         </div>
       </div>
     </div>

--- a/frontend/components/layout/DashboardLayout.tsx
+++ b/frontend/components/layout/DashboardLayout.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
 import { Sidebar } from './Sidebar';
-import { User } from 'lucide-react';
+import { User, RefreshCcw } from 'lucide-react';
 import { useWorkingCatalog } from '@/contexts/WorkingCatalogContext';
 import { WorkingCatalogModal } from '@/components/catalogos/WorkingCatalogModal';
 
@@ -91,11 +91,16 @@ export function DashboardLayout({ children, title = 'Dashboard' }: DashboardLayo
         </div>
 
         <div className="flex items-center space-x-3">
-          <button
-            className="text-sm text-gray-300 hover:text-white mr-2"
-            onClick={() => setCatalogModalOpen(true)}
-          >
+          <span className="text-sm text-gray-300 mr-1">
             {workingCatalog ? `${workingCatalog.numero} - ${workingCatalog.nome}` : 'Todos os catálogos'}
+          </span>
+          <button
+            className="p-1 rounded hover:bg-[#262b36] text-gray-300 hover:text-white"
+            onClick={() => setCatalogModalOpen(true)}
+            title="Trocar catálogo de trabalho"
+            aria-label="Trocar catálogo de trabalho"
+          >
+            <RefreshCcw size={16} />
           </button>
 
           <div className="relative" ref={userMenuRef}>


### PR DESCRIPTION
## Resumo
- Adiciona botão com ícone para troca de catálogo de trabalho
- Substitui listagem do modal por dropdown com visual padrão do sistema

## Testes
- `npm test` *(falhou: Environment variable not found: DATABASE_URL)*
- `npm run build:all`

------
https://chatgpt.com/codex/tasks/task_e_68a7c1a49f648330a551ebc1dd73f1a2