### PR TITLE
Atualiza script SQL do operador estrangeiro

### DIFF
--- a/backend/src/services/__tests__/operador-estrangeiro.service.test.ts
+++ b/backend/src/services/__tests__/operador-estrangeiro.service.test.ts
@@ -27,21 +27,21 @@ describe('OperadorEstrangeiroService - superUserId', () => {
     ;(catalogoPrisma.operadorEstrangeiro.findMany as jest.Mock).mockResolvedValue([])
     await service.listarTodos(undefined, 1)
     expect(catalogoPrisma.operadorEstrangeiro.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { superUserId: 1 } })
+      expect.objectContaining({ where: { catalogo: { superUserId: 1 } } })
     )
   })
 
-  it('inclui superUserId ao criar', async () => {
+  it('inclui catalogoId ao criar', async () => {
     ;(catalogoPrisma.operadorEstrangeiro.create as jest.Mock).mockResolvedValue({})
     await service.criar({
-      cnpjRaizResponsavel: '12345678000199',
+      catalogoId: 1,
       paisCodigo: 'BR',
       nome: 'Teste',
       situacao: OperadorEstrangeiroStatus.ATIVO,
       superUserId: 1
     })
     expect(catalogoPrisma.operadorEstrangeiro.create).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ superUserId: 1 }) })
+      expect.objectContaining({ data: expect.objectContaining({ catalogoId: 1 }) })
     )
   })
 
@@ -49,7 +49,7 @@ describe('OperadorEstrangeiroService - superUserId', () => {
     ;(catalogoPrisma.operadorEstrangeiro.update as jest.Mock).mockResolvedValue({})
     await service.remover(2, 1)
     expect(catalogoPrisma.operadorEstrangeiro.update).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: 2, superUserId: 1 } })
+      expect.objectContaining({ where: { id: 2 } })
     )
   })
 })

--- a/scripts_banco_catalogo_produtos.sql
+++ b/scripts_banco_catalogo_produtos.sql
@@ -97,22 +97,21 @@ DELIMITER ;
     -- Tabela principal do Operador Estrangeiro
     CREATE TABLE IF NOT EXISTS operador_estrangeiro (
         id INT UNSIGNED NOT NULL AUTO_INCREMENT,
-        cnpj_raiz_responsavel VARCHAR(14) NOT NULL,
-        super_user_id INT UNSIGNED NOT NULL,
-        
+        catalogo_id INT UNSIGNED NOT NULL,
+
         -- Dados básicos
         pais_codigo VARCHAR(10) NOT NULL,
         tin VARCHAR(50),
         nome VARCHAR(255) NOT NULL,
         email VARCHAR(255),
         codigo_interno VARCHAR(100),
-        
+
         -- Endereço
         codigo_postal VARCHAR(50),
         logradouro VARCHAR(500),
         cidade VARCHAR(255),
         subdivisao_codigo VARCHAR(20),
-        
+
         -- Controle do sistema
         codigo VARCHAR(50), -- Código gerado pelo SISCOMEX
         versao INT UNSIGNED NOT NULL DEFAULT 1,
@@ -120,22 +119,13 @@ DELIMITER ;
         data_inclusao DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
         data_ultima_alteracao DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
         data_referencia DATETIME, -- Para inclusão retroativa
-        
+
         PRIMARY KEY (id),
+        FOREIGN KEY (catalogo_id) REFERENCES catalogo(id),
         FOREIGN KEY (pais_codigo) REFERENCES pais(codigo),
         FOREIGN KEY (subdivisao_codigo) REFERENCES subdivisao(codigo),
-        INDEX idx_cnpj_raiz (cnpj_raiz_responsavel),
-        INDEX idx_tin (tin),
-        INDEX idx_nome (nome),
-        INDEX idx_situacao (situacao),
-        INDEX idx_super_user_id (super_user_id),
-        UNIQUE INDEX idx_tin_unique (tin) -- TIN deve ser único quando preenchido
+        INDEX idx_catalogo_id (catalogo_id)
     );
-
-    -- Vincula operadores existentes ao super usuário de seus catálogos
-    UPDATE operador_estrangeiro oe
-    JOIN catalogo c ON SUBSTRING(c.cpf_cnpj,1,8) = oe.cnpj_raiz_responsavel
-    SET oe.super_user_id = c.super_user_id;
 
     -- Tabela para identificações adicionais (DUNS, LEI, etc.)
     CREATE TABLE IF NOT EXISTS identificacao_adicional (


### PR DESCRIPTION
## Resumo
- ajusta tabela `operador_estrangeiro` para usar `catalogo_id`
- remove campos e índices obsoletos
- corrige testes do serviço de operador estrangeiro

## Testes
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_68a7de812a308330aca9957e5a2d00ff