### PR TITLE
Remover coluna "Última Alteração" da listagem de catálogos

### DIFF
--- a/frontend/pages/catalogos/index.tsx
+++ b/frontend/pages/catalogos/index.tsx
@@ -17,7 +17,6 @@ interface Catalogo {
   nome: string;
   cpf_cnpj: string | null;
   status: 'ATIVO' | 'INATIVO';
-  ultima_alteracao: string;
 }
 
 export default function CatalogosPage() {
@@ -44,11 +43,6 @@ export default function CatalogosPage() {
     } finally {
       setLoading(false);
     }
-  }
-
-  function formatarData(dataString: string) {
-    const data = new Date(dataString);
-    return data.toLocaleDateString('pt-BR') + ' ' + data.toLocaleTimeString('pt-BR');
   }
 
   // NOVA FUNÇÃO: Formatar CPF/CNPJ para exibição
@@ -147,7 +141,6 @@ export default function CatalogosPage() {
                   <th className="px-4 py-3">Nome</th>
                   <th className="px-4 py-3">CPF/CNPJ</th>
                   <th className="px-4 py-3">Status</th>
-                  <th className="px-4 py-3">Última Alteração</th>
                 </tr>
               </thead>
               <tbody>
@@ -194,7 +187,6 @@ export default function CatalogosPage() {
                         {catalogo.status}
                       </span>
                     </td>
-                    <td className="px-4 py-3">{formatarData(catalogo.ultima_alteracao)}</td>
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
## Resumo
- Remove campo de última alteração do tipo Catalogo
- Elimina coluna de última alteração da tabela de catálogos

## Testes
- `cd backend && npm test` (falhou: Environment variable not found: DATABASE_URL)
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_68aa0daeae608330a2d3f60cee67214f