### PR TITLE
Altera cor do botão de novo produto para vermelho

### DIFF
--- a/frontend/pages/produtos.tsx
+++ b/frontend/pages/produtos.tsx
@@ -205,7 +205,7 @@ export default function ProdutosPage() {
         <h1 className="text-2xl font-semibold text-white">Lista de Produtos</h1>
         <Link
           href="/produtos/novo"
-          className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors"
+          className="flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white font-medium py-2 px-4 rounded-lg transition-colors"
         >
           <Plus size={16} />
           <span>Novo Produto</span>
@@ -279,7 +279,7 @@ export default function ProdutosPage() {
         {produtosFiltrados.length === 0 ? (
           <div className="text-center py-10">
             <p className="text-gray-400 mb-4">Nenhum produto encontrado.</p>
-            <Link href="/produtos/novo" className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors">
+            <Link href="/produtos/novo" className="inline-flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white font-medium py-2 px-4 rounded-lg transition-colors">
               <Plus size={16} />
               <span>Adicionar Produto</span>
             </Link>


### PR DESCRIPTION
## Descrição
- altera classes do botão "Novo Produto" para usar vermelho em vez de azul

## Motivação
- dar maior destaque ao botão de criação de produto

## Testes
- `npm test` (falhou: Missing script)
- `npm run build:all`

------
https://chatgpt.com/codex/tasks/task_e_68aa0dbd12308330886f448a616e714c