### PR TITLE
Adiciona variáveis de S3 no .env.example e documenta uso

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ API_VERSION=v1
 # Ambiente da aplicação: local, hml ou prod
 APP_ENV=local
 
+# Credenciais AWS S3 (necessárias em hml/prod)
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=

--- a/docs/STORAGE_S3.md
+++ b/docs/STORAGE_S3.md
@@ -1,0 +1,17 @@
+# Armazenamento S3
+
+O backend utiliza diferentes provedores de armazenamento conforme o ambiente definido em `APP_ENV`.
+
+- **local**: usa o sistema de arquivos local.
+- **hml** ou **prod**: utiliza o `S3StorageProvider` para enviar e recuperar arquivos de um bucket da AWS.
+
+Para que o acesso ao S3 funcione nos ambientes de homologação e produção,
+é necessário definir as seguintes variáveis de ambiente:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION`
+
+Sem essas credenciais o cliente S3 não é configurado, causando erro ao tentar salvar ou ler arquivos.
+
+O bucket utilizado é `catprod-hml` quando `APP_ENV`=`hml` e `catprod-prd` quando `APP_ENV`=`prod`.


### PR DESCRIPTION
## Resumo
- adiciona variáveis de autenticação do S3 ao `.env.example`
- documenta funcionamento do storage S3 e variáveis necessárias

## Testes
- `npm test` (falhou: Missing script: "test")
- `npm test` em `backend` (falhou: Environment variable not found: DATABASE_URL)
- `npm build` (falhou: Unknown command: "build")
- `npm run build:all`

------
https://chatgpt.com/codex/tasks/task_e_68accf7e7c6483309da2966332006057