### PR TITLE
Adicionar upload de certificado pfx por catálogo

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,3 +17,4 @@ SISCOMEX_CERT_PATH=/path/to/certificado.pem
 SISCOMEX_KEY_PATH=/path/to/chave_privada.pem
 SISCOMEX_AMBIENTE=producao
 # Para ambiente de treinamento: https://val.portalunico.siscomex.gov.br
+CERT_PASSWORD_SECRET=chavehexadecimal32bytes

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -54,6 +54,8 @@ model Catalogo {
   numero           Int            @map("numero")
   status           CatalogoStatus @map("status")
   superUserId      Int            @map("super_user_id")
+  certificadoPfxPath String?      @map("certificado_pfx_path")
+  certificadoSenha   String?      @map("certificado_senha")
   produtos         Produto[]
   operadoresEstrangeiros OperadorEstrangeiro[]
 

--- a/backend/src/routes/catalogo.routes.ts
+++ b/backend/src/routes/catalogo.routes.ts
@@ -1,15 +1,18 @@
 // src/routes/catalogo.routes.ts
 import { Router } from 'express';
-import { 
+import {
   listarCatalogos,
   obterCatalogo,
   criarCatalogo,
   atualizarCatalogo,
-  removerCatalogo
+  removerCatalogo,
+  uploadCertificado,
+  downloadCertificado
 } from '../controllers/catalogo.controller';
 import { authMiddleware } from '../middlewares/auth.middleware';
 import { validate } from '../middlewares/validate.middleware';
 import { createCatalogoSchema, updateCatalogoSchema } from '../validators/catalogo.validator';
+import { uploadCertificadoSchema } from '../validators/catalogo-certificado.validator';
 
 const router = Router();
 
@@ -22,5 +25,7 @@ router.get('/:id', obterCatalogo);
 router.post('/', validate(createCatalogoSchema), criarCatalogo);
 router.put('/:id', validate(updateCatalogoSchema), atualizarCatalogo);
 router.delete('/:id', removerCatalogo);
+router.post('/:id/certificado', validate(uploadCertificadoSchema), uploadCertificado);
+router.get('/:id/certificado', downloadCertificado);
 
 export default router;

--- a/backend/src/utils/crypto.ts
+++ b/backend/src/utils/crypto.ts
@@ -1,0 +1,19 @@
+import crypto from 'crypto';
+
+const ALGORITHM = 'aes-256-ctr';
+const SECRET = process.env.CERT_PASSWORD_SECRET || ''.padEnd(32, '0');
+
+export function encrypt(text: string): string {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(ALGORITHM, Buffer.from(SECRET, 'hex'), iv);
+  const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+  return iv.toString('hex') + ':' + encrypted.toString('hex');
+}
+
+export function decrypt(hash: string): string {
+  const [ivHex, contentHex] = hash.split(':');
+  const iv = Buffer.from(ivHex, 'hex');
+  const decipher = crypto.createDecipheriv(ALGORITHM, Buffer.from(SECRET, 'hex'), iv);
+  const decrypted = Buffer.concat([decipher.update(Buffer.from(contentHex, 'hex')), decipher.final()]);
+  return decrypted.toString('utf8');
+}

--- a/backend/src/validators/catalogo-certificado.validator.ts
+++ b/backend/src/validators/catalogo-certificado.validator.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+export const uploadCertificadoSchema = z.object({
+  fileContent: z.string().min(1, { message: 'Arquivo é obrigatório' }),
+  password: z.string().min(1, { message: 'Senha é obrigatória' })
+});

--- a/scripts_banco_catalogo_produtos.sql
+++ b/scripts_banco_catalogo_produtos.sql
@@ -7,6 +7,8 @@ CREATE TABLE IF NOT EXISTS catalogo (
     numero INT UNSIGNED NOT NULL,
     status ENUM('ATIVO', 'INATIVO') NOT NULL DEFAULT 'ATIVO',
     super_user_id INT UNSIGNED NOT NULL,
+    certificado_pfx_path VARCHAR(255),
+    certificado_senha VARCHAR(255),
     PRIMARY KEY (id),
     UNIQUE INDEX idx_numero (numero),
     INDEX idx_super_user_id (super_user_id)


### PR DESCRIPTION
## Descrição
- permitir envio e download de certificado `.pfx` por catálogo
- armazenar senha do certificado de forma criptografada
- expor aba de certificado na edição de catálogo para upload ou download

## Testes
- `npm test` *(falhou: Environment variable not found: DATABASE_URL)*
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_68acd01e10148330a4617be01fff8ce8