### PR TITLE
Ajusta upload de certificado para PFX

### DIFF
--- a/frontend/components/ui/FileInput.tsx
+++ b/frontend/components/ui/FileInput.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Hint } from './Hint';
+
+interface FileInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+  hint?: string;
+}
+
+export function FileInput({ label, error, hint, className = '', ...props }: FileInputProps) {
+  return (
+    <div className={`mb-4 ${className}`}>
+      {label && (
+        <label className="block text-sm font-medium mb-1 text-gray-300" htmlFor={props.id}>
+          {label}
+          {props.required && <span className="text-red-400 ml-1">*</span>}
+          {hint && <Hint text={hint} />}
+        </label>
+      )}
+      <input
+        id={props.id}
+        type="file"
+        className="w-full text-sm text-gray-300 bg-[#1e2126] border border-gray-700 rounded-md file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-blue-600 file:text-white hover:file:bg-blue-700"
+        {...props}
+      />
+      {error && <p className="mt-1 text-sm text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/pages/catalogos/[id].tsx
+++ b/frontend/pages/catalogos/[id].tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Card } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
+import { FileInput } from '@/components/ui/FileInput';
 import { MaskedInput } from '@/components/ui/MaskedInput';
 import { Button } from '@/components/ui/Button';
 import { CustomSelect } from '@/components/ui/CustomSelect';
@@ -43,6 +44,22 @@ export default function CatalogoFormPage() {
   const [certFile, setCertFile] = useState<File | null>(null);
   const [certPassword, setCertPassword] = useState('');
   const [uploadingCert, setUploadingCert] = useState(false);
+
+  function handleCertFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) {
+      const isPfx =
+        file.name.toLowerCase().endsWith('.pfx') ||
+        file.type === 'application/x-pkcs12';
+      if (!isPfx) {
+        addToast('Apenas arquivos .pfx são permitidos', 'error');
+        e.target.value = '';
+        setCertFile(null);
+        return;
+      }
+    }
+    setCertFile(file || null);
+  }
   
   const router = useRouter();
   const { id } = router.query;
@@ -296,7 +313,7 @@ export default function CatalogoFormPage() {
         </div>
       ) : (
         <div className="space-y-4">
-          <input type="file" accept=".pfx" onChange={e => setCertFile(e.target.files?.[0] || null)} />
+          <FileInput label="Certificado (.pfx)" accept=".pfx" onChange={handleCertFileChange} />
           <Input label="Senha" type="password" value={certPassword} onChange={e => setCertPassword(e.target.value)} />
           <div className="flex gap-4">
             {catalogo?.certificadoPfxPath && (


### PR DESCRIPTION
## Resumo
- aplica componente de upload com estilo do sistema
- valida certificado enviado permitindo apenas arquivos .pfx

## Testes
- `npm test` *(falhou: Missing script: "test")*
- `npm run build`
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_68ad9a8844508330a849fd524ac9bc63