### PR TITLE
Impedir duplicidade de CNPJ/CPF nos catálogos

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -59,6 +59,7 @@ model Catalogo {
   produtos         Produto[]
   operadoresEstrangeiros OperadorEstrangeiro[]
 
+  @@unique([superUserId, cpf_cnpj], name: "uk_superuser_cpf_cnpj")
   @@map("catalogo")
 }
 

--- a/backend/src/services/__tests__/catalogo.service.test.ts
+++ b/backend/src/services/__tests__/catalogo.service.test.ts
@@ -1,0 +1,42 @@
+import { CatalogoService } from '../catalogo.service'
+import { catalogoPrisma } from '../../utils/prisma'
+import { CatalogoStatus } from '@prisma/client'
+
+jest.mock('../../utils/prisma', () => ({
+  catalogoPrisma: {
+    catalogo: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      updateMany: jest.fn()
+    }
+  }
+}))
+
+describe('CatalogoService - CPF/CNPJ duplicado', () => {
+  const service = new CatalogoService()
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('não permite criar catálogo com CPF/CNPJ já existente', async () => {
+    ;(catalogoPrisma.catalogo.findFirst as jest.Mock)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 1 })
+
+    await expect(
+      service.criar({ nome: 'Teste', cpf_cnpj: '12345678901', status: CatalogoStatus.ATIVO }, 1)
+    ).rejects.toThrow('Já existe um catálogo com este CPF/CNPJ')
+  })
+
+  it('não permite atualizar catálogo com CPF/CNPJ já existente', async () => {
+    ;(catalogoPrisma.catalogo.findFirst as jest.Mock)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 2 })
+
+    await expect(
+      service.atualizar(1, { nome: 'Teste', cpf_cnpj: '12345678901', status: CatalogoStatus.ATIVO }, 1)
+    ).rejects.toThrow('Já existe um catálogo com este CPF/CNPJ')
+    expect(catalogoPrisma.catalogo.updateMany).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/services/catalogo.service.ts
+++ b/backend/src/services/catalogo.service.ts
@@ -71,11 +71,20 @@ export class CatalogoService {
    */
   async criar(data: CreateCatalogoDTO, superUserId: number) {
     try {
-      const existente = await catalogoPrisma.catalogo.findFirst({
+      const existenteNome = await catalogoPrisma.catalogo.findFirst({
         where: { nome: data.nome, superUserId }
       });
-      if (existente) {
+      if (existenteNome) {
         throw new Error('Já existe um catálogo com este nome');
+      }
+
+      if (data.cpf_cnpj) {
+        const existenteCpf = await catalogoPrisma.catalogo.findFirst({
+          where: { cpf_cnpj: data.cpf_cnpj, superUserId }
+        });
+        if (existenteCpf) {
+          throw new Error('Já existe um catálogo com este CPF/CNPJ');
+        }
       }
       return await catalogoPrisma.catalogo.create({
         data: {
@@ -111,11 +120,20 @@ export class CatalogoService {
    */
   async atualizar(id: number, data: UpdateCatalogoDTO, superUserId: number) {
     try {
-      const existente = await catalogoPrisma.catalogo.findFirst({
+      const existenteNome = await catalogoPrisma.catalogo.findFirst({
         where: { nome: data.nome, superUserId, id: { not: id } }
       });
-      if (existente) {
+      if (existenteNome) {
         throw new Error('Já existe um catálogo com este nome');
+      }
+
+      if (data.cpf_cnpj) {
+        const existenteCpf = await catalogoPrisma.catalogo.findFirst({
+          where: { cpf_cnpj: data.cpf_cnpj, superUserId, id: { not: id } }
+        });
+        if (existenteCpf) {
+          throw new Error('Já existe um catálogo com este CPF/CNPJ');
+        }
       }
 
       const atualizado = await catalogoPrisma.catalogo.updateMany({


### PR DESCRIPTION
## Resumo
- garantir unicidade de CNPJ/CPF para catálogos no Prisma e no serviço
- cobrir cenário de duplicidade de CNPJ/CPF com testes unitários

## Testes
- `DATABASE_URL="mysql://user:pass@localhost:3306/db" npm test` *(falhou: Can't reach database server)*
- `DATABASE_URL="mysql://user:pass@localhost:3306/db" npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adc3f79de883308118be1cb7950fb7