### PR TITLE
Corrige inicialização do cliente S3

### DIFF
--- a/backend/src/services/s3-storage.service.ts
+++ b/backend/src/services/s3-storage.service.ts
@@ -1,55 +1,49 @@
+import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { Readable } from 'stream';
 import { StorageProvider } from './storage.interface';
 import { AppEnv } from '../utils/environment';
 
 export class S3StorageProvider implements StorageProvider {
-  private client: any;
-  private PutObjectCommand: any;
-  private GetObjectCommand: any;
-  private env: AppEnv;
+  private client: S3Client;
   private bucketRoot: string;
 
   constructor(env: AppEnv) {
-    this.env = env;
     this.bucketRoot = env === 'prod' ? 'catprod-prd' : 'catprod-hml';
-    try {
-      const aws = require('@aws-sdk/client-s3');
-      this.client = new aws.S3Client({
-        region: process.env.AWS_REGION || 'us-east-1',
-        credentials: process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY ? {
-          accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
-        } : undefined
-      });
-      this.PutObjectCommand = aws.PutObjectCommand;
-      this.GetObjectCommand = aws.GetObjectCommand;
-    } catch {
-      this.client = null;
-    }
+    this.client = new S3Client({
+      region: process.env.AWS_REGION || 'us-east-1',
+      credentials:
+        process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY
+          ? {
+              accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+              secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+            }
+          : undefined,
+    });
   }
 
   async upload(file: Buffer, path: string): Promise<string> {
-    if (!this.client) throw new Error('S3 client não configurado');
-    const command = new this.PutObjectCommand({
+    const command = new PutObjectCommand({
       Bucket: this.bucketRoot,
       Key: path,
-      Body: file
+      Body: file,
     });
     await this.client.send(command);
     return path;
   }
 
   async get(path: string): Promise<Buffer> {
-    if (!this.client) throw new Error('S3 client não configurado');
-    const command = new this.GetObjectCommand({
+    const command = new GetObjectCommand({
       Bucket: this.bucketRoot,
-      Key: path
+      Key: path,
     });
     const result = await this.client.send(command);
+    const body = result.Body as Readable | undefined;
+    if (!body) throw new Error('Resposta do S3 sem corpo');
     return await new Promise((resolve, reject) => {
       const chunks: Buffer[] = [];
-      result.Body.on('data', (chunk: Buffer) => chunks.push(chunk));
-      result.Body.on('end', () => resolve(Buffer.concat(chunks)));
-      result.Body.on('error', reject);
+      body.on('data', (chunk: Buffer) => chunks.push(chunk));
+      body.on('end', () => resolve(Buffer.concat(chunks)));
+      body.on('error', reject);
     });
   }
 }


### PR DESCRIPTION
## Descrição
- ajusta `S3StorageProvider` para importar o SDK de forma estática e instanciar o cliente diretamente
- trata leitura do corpo ao recuperar arquivos do S3

## Motivação e Contexto
A requisição de upload retornava `S3 client não configurado` porque a dependência `@aws-sdk/client-s3` era carregada dinamicamente dentro de um `try/catch` e qualquer falha silenciava o erro, deixando o cliente nulo.

## Como foi testado
- `npm test` *(falhou: Environment variable not found: DATABASE_URL)*
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_68ade8d7fae88330a9d47cd6e5c43891