### PR TITLE
Adiciona número interno aleatório aos produtos

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -219,6 +219,7 @@ model Produto {
   modalidade                String?           @map("modalidade")
   denominacao               String            @map("denominacao")
   descricao                 String            @map("descricao")
+  numero                    Int               @unique @map("numero")
   catalogoId                Int               @map("catalogo_id")
   catalogo                  Catalogo          @relation(fields: [catalogoId], references: [id])
   criadoEm                  DateTime          @default(now()) @map("criado_em")

--- a/backend/src/services/produto.service.ts
+++ b/backend/src/services/produto.service.ts
@@ -67,6 +67,7 @@ export class ProdutoService {
 
     return produtos.map(p => ({
       ...p,
+      numero: p.numero,
       codigosInternos: p.codigosInternos.map(ci => ci.codigo),
       operadoresEstrangeiros: p.operadoresEstrangeiros.map(o => ({
         id: o.id,
@@ -94,6 +95,7 @@ export class ProdutoService {
     if (!p) return null;
     return {
       ...p,
+      numero: p.numero,
       codigosInternos: p.codigosInternos.map(ci => ci.codigo),
       operadoresEstrangeiros: p.operadoresEstrangeiros.map(o => ({
         id: o.id,
@@ -146,6 +148,7 @@ export class ProdutoService {
           modalidade: data.modalidade,
           denominacao: data.denominacao,
           descricao: data.descricao,
+          numero: 0,
           catalogoId: data.catalogoId,
           versaoEstruturaAtributos: 1,
           criadoPor: data.criadoPor || null,


### PR DESCRIPTION
## Resumo
- adiciona campo `numero` em Produto com geração automática
- aplica gatilhos e função SQL para garantir números únicos
- retorna o número do produto nos serviços

## Testes
- `npm build` *(falhou: Unknown command: "build")*
- `npm run build:all`
- `npm test` *(falhou: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5715ef0883309216eed9244a4c37