### PR TITLE
Muda cor do número do catálogo para vermelho

### DIFF
--- a/frontend/pages/catalogos/index.tsx
+++ b/frontend/pages/catalogos/index.tsx
@@ -179,7 +179,7 @@ export default function CatalogosPage() {
                         <Trash2 size={16} />
                       </button>
                     </td>
-                    <td className="px-4 py-3 font-mono text-[#f59e0b]">{catalogo.numero}</td>
+                    <td className="px-4 py-3 font-mono text-red-500">{catalogo.numero}</td>
                     <td className="px-4 py-3 font-medium text-white">{catalogo.nome}</td>
                     {/* CORRIGIDO: CPF/CNPJ formatado */}
                     <td className="px-4 py-3 font-mono">


### PR DESCRIPTION
## Resumo
- altera o número da listagem de catálogos para vermelho

## Testes
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b0d77803108327b19a577014258f27