### PR TITLE
Gerir certificados com nome e ações

### DIFF
--- a/backend/src/controllers/certificado.controller.ts
+++ b/backend/src/controllers/certificado.controller.ts
@@ -26,3 +26,38 @@ export async function uploadCertificado(req: Request, res: Response) {
     return res.status(500).json({ error: message });
   }
 }
+
+export async function listarCatalogosCertificado(req: Request, res: Response) {
+  const { id } = req.params;
+  try {
+    const catalogos = await certificadoService.listarCatalogos(Number(id), req.user!.superUserId);
+    return res.status(200).json(catalogos);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Erro ao listar catálogos do certificado';
+    return res.status(500).json({ error: message });
+  }
+}
+
+export async function downloadCertificado(req: Request, res: Response) {
+  const { id } = req.params;
+  try {
+    const { file, nome } = await certificadoService.obterArquivo(Number(id), req.user!.superUserId);
+    res.setHeader('Content-Type', 'application/x-pkcs12');
+    res.setHeader('Content-Disposition', `attachment; filename=${nome}.pfx`);
+    return res.send(file);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Erro ao baixar certificado';
+    return res.status(500).json({ error: message });
+  }
+}
+
+export async function removerCertificado(req: Request, res: Response) {
+  const { id } = req.params;
+  try {
+    await certificadoService.remover(Number(id), req.user!.superUserId);
+    return res.status(204).send();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Erro ao remover certificado';
+    return res.status(500).json({ error: message });
+  }
+}

--- a/backend/src/routes/certificado.routes.ts
+++ b/backend/src/routes/certificado.routes.ts
@@ -1,5 +1,11 @@
 import { Router } from 'express';
-import { listarCertificados, uploadCertificado } from '../controllers/certificado.controller';
+import {
+  listarCertificados,
+  uploadCertificado,
+  listarCatalogosCertificado,
+  removerCertificado,
+  downloadCertificado,
+} from '../controllers/certificado.controller';
 import { authMiddleware } from '../middlewares/auth.middleware';
 import { validate } from '../middlewares/validate.middleware';
 import { uploadCertificadoSchema } from '../validators/certificado.validator';
@@ -9,5 +15,8 @@ const router = Router();
 router.use(authMiddleware);
 router.get('/', listarCertificados);
 router.post('/', validate(uploadCertificadoSchema), uploadCertificado);
+router.get('/:id/catalogos', listarCatalogosCertificado);
+router.get('/:id/download', downloadCertificado);
+router.delete('/:id', removerCertificado);
 
 export default router;

--- a/backend/src/services/local-storage.service.ts
+++ b/backend/src/services/local-storage.service.ts
@@ -16,4 +16,9 @@ export class LocalStorageProvider implements StorageProvider {
     const fullPath = path.join(this.baseDir, filePath);
     return fs.readFile(fullPath);
   }
+
+  async delete(filePath: string): Promise<void> {
+    const fullPath = path.join(this.baseDir, filePath);
+    await fs.unlink(fullPath).catch(() => {});
+  }
 }

--- a/backend/src/services/s3-storage.service.ts
+++ b/backend/src/services/s3-storage.service.ts
@@ -1,4 +1,4 @@
-import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { Readable } from 'stream';
 import { StorageProvider } from './storage.interface';
 import { AppEnv } from '../utils/environment';
@@ -45,5 +45,13 @@ export class S3StorageProvider implements StorageProvider {
       body.on('end', () => resolve(Buffer.concat(chunks)));
       body.on('error', reject);
     });
+  }
+
+  async delete(path: string): Promise<void> {
+    const command = new DeleteObjectCommand({
+      Bucket: this.bucketRoot,
+      Key: path,
+    });
+    await this.client.send(command);
   }
 }

--- a/backend/src/services/storage.interface.ts
+++ b/backend/src/services/storage.interface.ts
@@ -1,4 +1,5 @@
 export interface StorageProvider {
   upload(file: Buffer, path: string): Promise<string>;
   get(path: string): Promise<Buffer>;
+  delete(path: string): Promise<void>;
 }


### PR DESCRIPTION
## Resumo
- permitir informar nome ao enviar certificado
- adicionar download e remoção com confirmação e lista de catálogos

## Testes
- `npm run build:all`

------
https://chatgpt.com/codex/tasks/task_e_68aef1561e108330a4a867558f7a391d