### PR TITLE
Definir bucket via env e padronizar caminhos de upload

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,7 @@ API_VERSION=v1
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=
+S3_BUCKET_NAME=catpro-hml # catpro em produção
 
 # Configurações SISCOMEX
 SISCOMEX_API_URL=https://api.portalunico.siscomex.gov.br

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -7,3 +7,4 @@ export const DATABASE_URL = process.env.DATABASE_URL || '';
 export const API_VERSION = process.env.API_VERSION || 'v1';
 export const API_PREFIX = `/api/${API_VERSION}`;
 export const APP_ENV = (process.env.APP_ENV || 'local').toLowerCase();
+export const S3_BUCKET_NAME = process.env.S3_BUCKET_NAME || '';

--- a/backend/src/routes/upload.routes.ts
+++ b/backend/src/routes/upload.routes.ts
@@ -1,25 +1,29 @@
 import { Router } from 'express';
 import { storageFactory } from '../services/storage.factory';
-import { getBucketName } from '../utils/environment';
+import { getStoragePath } from '../utils/environment';
 
 const router = Router();
 
 router.post('/', async (req, res) => {
-  const { fileName, fileContent, identifier, catalogo, type } = req.body as {
+  const { fileName, fileContent, identifier, catalogo, produto, type } = req.body as {
     fileName?: string;
     fileContent?: string;
     identifier?: string;
     catalogo?: string;
+    produto?: string;
     type?: 'certificados' | 'anexos';
   };
 
   if (!fileName || !fileContent || !identifier || !type) {
     return res.status(400).json({ error: 'Parâmetros obrigatórios ausentes' });
   }
+  if (type === 'anexos' && (!catalogo || !produto)) {
+    return res.status(400).json({ error: 'catalogo e produto são obrigatórios para anexos' });
+  }
 
   try {
     const provider = storageFactory();
-    const base = getBucketName({ identifier, catalogo, type });
+    const base = getStoragePath({ identifier, catalogo, produto, type });
     const path = `${base}/${fileName}`;
     const buffer = Buffer.from(fileContent, 'base64');
     await provider.upload(buffer, path);

--- a/backend/src/services/__tests__/storage.factory.test.ts
+++ b/backend/src/services/__tests__/storage.factory.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 describe('StorageFactory', () => {
   afterEach(async () => {
     delete process.env.APP_ENV;
+    delete process.env.S3_BUCKET_NAME;
     jest.resetModules();
     await fs.rm(path.resolve('uploads'), { recursive: true, force: true });
   });
@@ -22,6 +23,7 @@ describe('StorageFactory', () => {
 
   it('deve usar S3 quando APP_ENV=hml', async () => {
     process.env.APP_ENV = 'hml';
+    process.env.S3_BUCKET_NAME = 'test-bucket';
     const { storageFactory } = await import('../storage.factory');
     const { S3StorageProvider } = await import('../s3-storage.service');
     const provider = storageFactory();

--- a/backend/src/services/certificado.service.ts
+++ b/backend/src/services/certificado.service.ts
@@ -1,7 +1,7 @@
 import { catalogoPrisma } from '../utils/prisma';
 import { encrypt } from '../utils/crypto';
 import { storageFactory } from './storage.factory';
-import { getBucketName } from '../utils/environment';
+import { getStoragePath } from '../utils/environment';
 
 export interface UploadCertificadoDTO {
   nome: string;
@@ -19,7 +19,7 @@ export class CertificadoService {
 
   async criar(data: UploadCertificadoDTO, superUserId: number) {
     const provider = storageFactory();
-    const base = getBucketName({ identifier: String(superUserId), type: 'certificados' });
+    const base = getStoragePath({ identifier: String(superUserId), type: 'certificados' });
     const path = `${base}/${data.nome}.pfx`;
     const buffer = Buffer.from(data.fileContent, 'base64');
     await provider.upload(buffer, path);

--- a/backend/src/services/s3-storage.service.ts
+++ b/backend/src/services/s3-storage.service.ts
@@ -1,14 +1,17 @@
 import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { Readable } from 'stream';
 import { StorageProvider } from './storage.interface';
-import { AppEnv } from '../utils/environment';
+import { S3_BUCKET_NAME } from '../config';
 
 export class S3StorageProvider implements StorageProvider {
   private client: S3Client;
   private bucketRoot: string;
 
-  constructor(env: AppEnv) {
-    this.bucketRoot = env === 'prod' ? 'catprod-prd' : 'catprod-hml';
+  constructor() {
+    this.bucketRoot = S3_BUCKET_NAME;
+    if (!this.bucketRoot) {
+      throw new Error('S3_BUCKET_NAME não configurado');
+    }
     this.client = new S3Client({
       region: process.env.AWS_REGION || 'us-east-1',
       credentials:

--- a/backend/src/services/storage.factory.ts
+++ b/backend/src/services/storage.factory.ts
@@ -7,5 +7,5 @@ export function storageFactory(): StorageProvider {
   if (APP_ENV === 'local') {
     return new LocalStorageProvider();
   }
-  return new S3StorageProvider(APP_ENV as any);
+  return new S3StorageProvider();
 }

--- a/backend/src/utils/environment.ts
+++ b/backend/src/utils/environment.ts
@@ -6,28 +6,21 @@ export const isLocal = (): boolean => APP_ENV === 'local';
 export const isHml = (): boolean => APP_ENV === 'hml';
 export const isProd = (): boolean => APP_ENV === 'prod';
 
-interface BucketParams {
+interface StoragePathParams {
   identifier: string; // id_superuser ou cnpj
   catalogo?: string; // codigo do catalogo
+  produto?: string; // numero do produto
   type: 'certificados' | 'anexos';
-  env?: AppEnv;
 }
 
-export function getBucketName({ identifier, catalogo, type, env = APP_ENV as AppEnv }: BucketParams): string {
-  if (env === 'local') {
-    const base = type === 'certificados'
-      ? `${identifier}/certificados`
-      : `${identifier}/${catalogo}/anexos`;
-    return base;
-  }
-  const root = env === 'prod' ? 'catprod-prd' : 'catprod-hml';
+export function getStoragePath({ identifier, catalogo, produto, type }: StoragePathParams): string {
   if (type === 'certificados') {
-    return `${root}/${identifier}/certificados`;
+    return `${identifier}/certificados`;
   }
-  if (!catalogo) {
-    throw new Error('catalogo é obrigatório para anexos');
+  if (!catalogo || !produto) {
+    throw new Error('catalogo e produto são obrigatórios para anexos');
   }
-  return `${root}/${identifier}/${catalogo}/anexos`;
+  return `${identifier}/${catalogo}/${produto}`;
 }
 
 export type { AppEnv };


### PR DESCRIPTION
## Resumo
- lê o nome do bucket a partir da variável de ambiente `S3_BUCKET_NAME`
- ajusta o provedor S3 e a factory de storage para usar o bucket configurável
- padroniza os caminhos de upload para certificados e anexos, incluindo número do produto
- documenta `S3_BUCKET_NAME` no `.env.example` do backend

## Testes
- `npm test` *(falhou: Can't reach database server at `localhost:3306`)*
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_68adeb2e3ea0833080a2ea7d7cced593