### PR TITLE
Registrar usuário após login

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -50,6 +50,20 @@ model Certificado {
   @@map("certificado")
 }
 
+model UsuarioCatalogo {
+  id          Int      @id @default(autoincrement()) @map("id")
+  legacyId    Int      @map("legacy_id")
+  username    String   @unique @map("username")
+  nome        String   @map("nome")
+  superUserId Int      @map("super_user_id")
+  role        String   @map("role")
+  ultimoLogin DateTime @default(now()) @map("ultimo_login")
+  criadoEm    DateTime @default(now()) @map("criado_em")
+  atualizadoEm DateTime @updatedAt @map("atualizado_em")
+
+  @@map("usuario_catalogo")
+}
+
 enum Role {
   ADMIN
   SUPERUSER

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -40,6 +40,9 @@ export async function login(req: Request, res: Response) {
     // Remove a senha do objeto
     const { password: _pwd, ...userData } = user;
 
+    // Registra/atualiza o usuário no catálogo
+    await authService.registerUserLogin(userData);
+
     // Gera o token JWT
     const token = generateToken(userData);
 

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,5 +1,5 @@
 // backend/src/services/auth.service.ts
-import { legacyPrisma } from '../utils/prisma';
+import { legacyPrisma, catalogoPrisma } from '../utils/prisma';
 import { logger } from '../utils/logger';
 import aprMd5 from 'apache-md5';
 import { AuthUser } from '../interfaces/auth-user';
@@ -97,5 +97,33 @@ export class AuthService {
    */
   formatUserData(user: AuthUser): AuthUser {
     return { ...user };
+  }
+
+  /**
+   * Registra ou atualiza os dados do usuário no catálogo após login
+   */
+  async registerUserLogin(user: AuthUser): Promise<void> {
+    try {
+      await catalogoPrisma.usuarioCatalogo.upsert({
+        where: { username: user.email },
+        update: {
+          nome: user.name,
+          legacyId: user.id,
+          superUserId: user.superUserId,
+          role: user.role,
+          ultimoLogin: new Date(),
+        },
+        create: {
+          username: user.email,
+          nome: user.name,
+          legacyId: user.id,
+          superUserId: user.superUserId,
+          role: user.role,
+          ultimoLogin: new Date(),
+        },
+      });
+    } catch (error: unknown) {
+      logger.error(`Erro ao registrar usuário no catálogo: ${user.email}`, error);
+    }
   }
 }

--- a/scripts_banco_catalogo_produtos.sql
+++ b/scripts_banco_catalogo_produtos.sql
@@ -1,3 +1,18 @@
+-- Criar tabela de registro de usuários autenticados
+CREATE TABLE IF NOT EXISTS usuario_catalogo (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    legacy_id INT UNSIGNED NOT NULL,
+    username VARCHAR(255) NOT NULL,
+    nome VARCHAR(255) NOT NULL,
+    super_user_id INT UNSIGNED NOT NULL,
+    role VARCHAR(10) NOT NULL,
+    ultimo_login DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    criado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    atualizado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE INDEX uk_usuario_catalogo_username (username)
+);
+
 -- Criar tabela de certificados
 CREATE TABLE IF NOT EXISTS certificado (
     id INT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -434,3 +449,19 @@ DELIMITER ;
     ('ISO', 'ISO', 'International Organization for Standardization'),
     ('WTO', 'WTO', 'World Trade Organization'),
     ('WCO', 'WCO', 'World Customs Organization');
+
+-- Atualização para bases existentes
+-- Execute o bloco abaixo em bancos já criados para registrar usuários autenticados
+-- CREATE TABLE usuario_catalogo (
+--     id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+--     legacy_id INT UNSIGNED NOT NULL,
+--     username VARCHAR(255) NOT NULL,
+--     nome VARCHAR(255) NOT NULL,
+--     super_user_id INT UNSIGNED NOT NULL,
+--     role VARCHAR(10) NOT NULL,
+--     ultimo_login DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+--     criado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+--     atualizado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+--     PRIMARY KEY (id),
+--     UNIQUE INDEX uk_usuario_catalogo_username (username)
+-- );


### PR DESCRIPTION
## Resumo
- registrar dados de login no catálogo
- atualizar estrutura SQL para usuários autenticados

## Testes
- `npm test` *(falhou: Environment variable not found: DATABASE_URL)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b63a98104c8327bc265bbd7ab06c65