### PR TITLE
Exibir erro do backend ao salvar catálogo

### DIFF
--- a/frontend/pages/catalogos/[id].tsx
+++ b/frontend/pages/catalogos/[id].tsx
@@ -163,6 +163,19 @@ export default function CatalogoFormPage() {
     return Object.keys(newErrors).length === 0;
   }
 
+  function handleApiError(error: any) {
+    if (error.response?.status === 400 && error.response?.data?.details) {
+      const details = error.response.data.details
+        .map((d: any) => `${d.field}: ${d.message}`)
+        .join('; ');
+      addToast(`Erro de validação: ${details}`, 'error');
+    } else if (error.response?.data?.error) {
+      addToast(error.response.data.error, 'error');
+    } else {
+      addToast('Erro ao salvar catálogo', 'error');
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     
@@ -182,9 +195,9 @@ export default function CatalogoFormPage() {
       }
       
       router.push('/catalogos');
-    } catch (error) {
+    } catch (error: any) {
       console.error('Erro ao salvar catálogo:', error);
-      addToast('Erro ao salvar catálogo', 'error');
+      handleApiError(error);
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
## Resumo
- mostrar mensagem específica do backend ao falhar o salvamento de um catálogo

## Testes
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_68bb6a014df083309797ff9c028648b7