### PR TITLE
Corrige número de produtos ao clonar catálogo

### DIFF
--- a/backend/src/services/catalogo.service.ts
+++ b/backend/src/services/catalogo.service.ts
@@ -367,7 +367,7 @@ async clonar(id: number, nome: string, cpf_cnpj: string, superUserId: number) {
       const attr = prod.atributos[0];
       await tx.produto.create({
         data: {
-          codigo: prod.codigo,
+          codigo: null,
           versao: prod.versao,
           status: prod.status,
           situacao: prod.situacao,


### PR DESCRIPTION
## Resumo
- impede que o serviço de clonagem copie o código SISCOMEX dos produtos originais
- garante que o número/código do produto clonado seja regenerado de forma aleatória pelo banco, como em novas criações

## Testes
- npm run build:all

------
https://chatgpt.com/codex/tasks/task_e_68cdbcd001e8833099eb94beb3123c2e