### PR TITLE
feat: suportar mascaras dinamicas nos atributos de produto

### DIFF
--- a/frontend/lib/masks.ts
+++ b/frontend/lib/masks.ts
@@ -1,0 +1,72 @@
+// frontend/lib/masks.ts
+// Utilitários para aplicar máscaras dinâmicas baseadas em padrões vindos do backend.
+
+const PATTERN_PLACEHOLDER = '#';
+
+/**
+ * Remove todos os caracteres que não são dígitos.
+ * Mantemos apenas números porque os padrões do backend utilizam '#'
+ * para representar posições numéricas.
+ */
+export function stripNonDigits(value: string): string {
+  return value.replace(/\D/g, '');
+}
+
+/**
+ * Conta o número de placeholders disponíveis em um padrão.
+ */
+function countPlaceholders(pattern: string): number {
+  return (pattern.match(new RegExp(PATTERN_PLACEHOLDER, 'g')) || []).length;
+}
+
+/**
+ * Aplica o padrão informado ao valor digitado, retornando tanto a versão
+ * formatada quanto a representação sem os caracteres especiais.
+ */
+export function formatValueWithPattern(value: string, pattern: string): {
+  formatted: string;
+  clean: string;
+} {
+  const digitsOnly = stripNonDigits(value);
+  const maxDigits = countPlaceholders(pattern);
+  const limitedDigits = digitsOnly.slice(0, maxDigits);
+
+  let formatted = '';
+  let digitIndex = 0;
+
+  for (const char of pattern) {
+    if (char === PATTERN_PLACEHOLDER) {
+      if (digitIndex < limitedDigits.length) {
+        formatted += limitedDigits[digitIndex];
+        digitIndex += 1;
+      } else {
+        break;
+      }
+    } else {
+      if (digitIndex < limitedDigits.length) {
+        formatted += char;
+      } else {
+        break;
+      }
+    }
+  }
+
+  return {
+    formatted,
+    clean: limitedDigits,
+  };
+}
+
+/**
+ * Sugestão de placeholder para inputs com padrão dinâmico.
+ */
+export function getPatternPlaceholder(pattern: string): string {
+  return pattern.replace(new RegExp(PATTERN_PLACEHOLDER, 'g'), '0');
+}
+
+/**
+ * Tamanho máximo permitido no input com base no padrão informado.
+ */
+export function getPatternMaxLength(pattern: string): number {
+  return pattern.length;
+}

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -28,6 +28,7 @@ interface AtributoEstrutura {
   dominio?: { codigo: string; descricao: string }[];
   validacoes?: {
     tamanho_maximo?: number;
+    mascara?: string;
     [key: string]: any;
   };
   descricaoCondicao?: string;
@@ -393,6 +394,27 @@ export default function ProdutoPage() {
       default:
         if (attr.tipo === 'TEXTO') {
           const max = attr.validacoes?.tamanho_maximo ?? 0;
+          const pattern = attr.validacoes?.mascara;
+
+          if (pattern) {
+            let span = 'col-span-1';
+            if (max > 30 && max <= 60) span = 'col-span-2';
+            else if (max > 60) span = 'col-span-3';
+
+            return (
+              <MaskedInput
+                key={attr.codigo}
+                label={attr.nome}
+                hint={attr.orientacaoPreenchimento}
+                required={attr.obrigatorio}
+                value={value}
+                pattern={pattern}
+                onChange={(valorLimpo, _formatado) => handleValor(attr.codigo, valorLimpo)}
+                className={span}
+              />
+            );
+          }
+
           if (max >= 100) {
             return (
               <div key={attr.codigo} className="col-span-3 mb-4">


### PR DESCRIPTION
## Resumo
- permitir que a interface de atributos de produto carregue a máscara enviada pelo backend
- criar utilitário para aplicar padrões vindos do backend e reaproveitar no componente MaskedInput
- utilizar o campo mascarado ao renderizar atributos de texto com máscara, persistindo o valor limpo

## Testes
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2148e37488330a1ec9ad172de9948