### PR TITLE
Permite múltiplos valores nos atributos do produto

### DIFF
--- a/backend/src/services/__tests__/produto.service.test.ts
+++ b/backend/src/services/__tests__/produto.service.test.ts
@@ -31,6 +31,82 @@ describe('ProdutoService - atributos obrigatórios', () => {
   })
 })
 
+describe('ProdutoService - atributos multivalorados', () => {
+  it('considera arrays vazios como não preenchidos', () => {
+    const service = new ProdutoService()
+    const estrutura: AtributoEstruturaDTO[] = [
+      {
+        codigo: 'M',
+        nome: 'Multi',
+        tipo: 'LISTA_ESTATICA',
+        obrigatorio: true,
+        multivalorado: true,
+        validacoes: {},
+        dominio: [
+          { codigo: '1', descricao: 'Um' },
+          { codigo: '2', descricao: 'Dois' }
+        ]
+      }
+    ]
+
+    expect((service as any).todosObrigatoriosPreenchidos({ M: ['1'] }, estrutura)).toBe(true)
+    expect((service as any).todosObrigatoriosPreenchidos({ M: [] }, estrutura)).toBe(false)
+  })
+
+  it('avalia condições com qualquer valor selecionado', () => {
+    const service = new ProdutoService()
+    const estrutura: AtributoEstruturaDTO[] = [
+      {
+        codigo: 'M',
+        nome: 'Multi',
+        tipo: 'LISTA_ESTATICA',
+        obrigatorio: true,
+        multivalorado: true,
+        validacoes: {},
+        dominio: [
+          { codigo: '1', descricao: 'Um' },
+          { codigo: '2', descricao: 'Dois' }
+        ]
+      },
+      {
+        codigo: 'D',
+        nome: 'Dependente',
+        tipo: 'TEXTO',
+        obrigatorio: true,
+        multivalorado: false,
+        validacoes: {},
+        parentCodigo: 'M',
+        condicao: { operador: '==', valor: '2' }
+      }
+    ]
+
+    expect((service as any).todosObrigatoriosPreenchidos({ M: ['1', '2'], D: 'ok' }, estrutura)).toBe(true)
+    expect((service as any).todosObrigatoriosPreenchidos({ M: ['1', '2'] }, estrutura)).toBe(false)
+    expect((service as any).todosObrigatoriosPreenchidos({ M: ['1'] }, estrutura)).toBe(true)
+  })
+
+  it('valida cada item do array contra o domínio', () => {
+    const service = new ProdutoService()
+    const estrutura: AtributoEstruturaDTO[] = [
+      {
+        codigo: 'M',
+        nome: 'Multi',
+        tipo: 'LISTA_ESTATICA',
+        obrigatorio: true,
+        multivalorado: true,
+        validacoes: {},
+        dominio: [
+          { codigo: '1', descricao: 'Um' },
+          { codigo: '2', descricao: 'Dois' }
+        ]
+      }
+    ]
+
+    expect((service as any).validarValores({ M: ['1', '2'] }, estrutura)).toEqual({})
+    expect((service as any).validarValores({ M: ['1', '3'] }, estrutura)).toEqual({ M: 'Valor fora do domínio' })
+  })
+})
+
 describe('ProdutoService - atualização de status', () => {
   it('marca como PENDENTE quando faltam atributos obrigatórios', async () => {
     const service = new ProdutoService()

--- a/frontend/components/ui/MultiSelect.tsx
+++ b/frontend/components/ui/MultiSelect.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { ChevronDown, Check } from 'lucide-react';
+import { Hint } from './Hint';
 
 export interface MultiOption {
   value: string;
@@ -17,6 +18,8 @@ interface MultiSelectProps {
   disabled?: boolean;
   error?: string;
   className?: string;
+  hint?: string;
+  required?: boolean;
 }
 
 export function MultiSelect({
@@ -28,6 +31,8 @@ export function MultiSelect({
   disabled = false,
   error,
   className = '',
+  hint,
+  required,
 }: MultiSelectProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -91,7 +96,11 @@ export function MultiSelect({
   return (
     <div className={`mb-4 ${className}`} ref={containerRef}>
       {label && (
-        <label className="block text-sm font-medium mb-2 text-gray-300">{label}</label>
+        <label className="block text-sm font-medium mb-2 text-gray-300">
+          {label}
+          {required && <span className="text-red-400 ml-1">*</span>}
+          {hint && <Hint text={hint} />}
+        </label>
       )}
       <div className="relative">
         <button

--- a/frontend/lib/__tests__/atributos.test.ts
+++ b/frontend/lib/__tests__/atributos.test.ts
@@ -1,0 +1,63 @@
+// frontend/lib/__tests__/atributos.test.ts
+import assert from 'node:assert/strict';
+import {
+  algumValorIgual,
+  algumValorSatisfazCondicao,
+  isValorPreenchido,
+  normalizarValoresMultivalorados,
+} from '../atributos.ts';
+
+const condicaoIgualB = { operador: '==', valor: 'B' };
+const condicaoMaiorQue5 = { operador: '>', valor: '5' };
+
+const casos = [
+  {
+    descricao: 'identifica valores preenchidos em strings e arrays',
+    exec: () => {
+      assert.equal(isValorPreenchido(undefined), false);
+      assert.equal(isValorPreenchido(''), false);
+      assert.equal(isValorPreenchido(['', '   ']), false);
+      assert.equal(isValorPreenchido('valor'), true);
+      assert.equal(isValorPreenchido(['', 'A']), true);
+    }
+  },
+  {
+    descricao: 'normaliza valores multivalorados para arrays de strings',
+    exec: () => {
+      assert.deepEqual(normalizarValoresMultivalorados(undefined), []);
+      assert.deepEqual(normalizarValoresMultivalorados('A'), ['A']);
+      assert.deepEqual(normalizarValoresMultivalorados(['A', 'B']), ['A', 'B']);
+      assert.deepEqual(normalizarValoresMultivalorados(['', 'C']), ['C']);
+    }
+  },
+  {
+    descricao: 'avalia condições considerando qualquer valor da coleção',
+    exec: () => {
+      assert.equal(algumValorSatisfazCondicao(condicaoIgualB, ['A', 'B']), true);
+      assert.equal(algumValorSatisfazCondicao(condicaoIgualB, ['A', 'C']), false);
+      assert.equal(algumValorSatisfazCondicao(condicaoMaiorQue5, ['3', '6']), true);
+      assert.equal(algumValorSatisfazCondicao(condicaoMaiorQue5, []), false);
+    }
+  },
+  {
+    descricao: 'verifica igualdade considerando múltiplos valores',
+    exec: () => {
+      assert.equal(algumValorIgual(['A', 'B'], 'B'), true);
+      assert.equal(algumValorIgual(['A', 'B'], 'C'), false);
+      assert.equal(algumValorIgual('A', 'A'), true);
+      assert.equal(algumValorIgual(undefined, 'A'), false);
+    }
+  }
+];
+
+casos.forEach(({ descricao, exec }) => {
+  try {
+    exec();
+    console.log(`✔ ${descricao}`);
+  } catch (error) {
+    console.error(`✖ ${descricao}`);
+    throw error;
+  }
+});
+
+console.log('Todos os testes utilitários de atributos passaram.');

--- a/frontend/lib/atributos.ts
+++ b/frontend/lib/atributos.ts
@@ -1,0 +1,67 @@
+// frontend/lib/atributos.ts
+export type ValorDinamico = string | number | (string | number)[] | null | undefined;
+
+function flattenValores(valor: ValorDinamico): string[] {
+  if (Array.isArray(valor)) {
+    return valor.reduce<string[]>(
+      (acc, item) => acc.concat(flattenValores(item as ValorDinamico)),
+      []
+    );
+  }
+  if (valor === undefined || valor === null) return [];
+  const texto = String(valor);
+  return texto.trim() === '' ? [] : [texto];
+}
+
+export function isValorPreenchido(valor: ValorDinamico): boolean {
+  return flattenValores(valor).length > 0;
+}
+
+export function normalizarValoresMultivalorados(valor: ValorDinamico): string[] {
+  return flattenValores(valor);
+}
+
+export function avaliarExpressao(cond: any, valor: string): boolean {
+  if (!cond) return true;
+  const esperado = cond.valor;
+  let ok = true;
+  switch (cond.operador) {
+    case '==':
+      ok = valor === esperado;
+      break;
+    case '!=':
+      ok = valor !== esperado;
+      break;
+    case '>':
+      ok = Number(valor) > Number(esperado);
+      break;
+    case '>=':
+      ok = Number(valor) >= Number(esperado);
+      break;
+    case '<':
+      ok = Number(valor) < Number(esperado);
+      break;
+    case '<=':
+      ok = Number(valor) <= Number(esperado);
+      break;
+  }
+  if (cond.condicao) {
+    const next = avaliarExpressao(cond.condicao, valor);
+    return cond.composicao === '||' ? ok || next : ok && next;
+  }
+  return ok;
+}
+
+export function algumValorSatisfazCondicao(cond: any, valor: ValorDinamico): boolean {
+  if (!cond) return true;
+  const valores = flattenValores(valor);
+  if (valores.length === 0) return false;
+  return valores.some(v => avaliarExpressao(cond, v));
+}
+
+export function algumValorIgual(valor: ValorDinamico, esperado: string): boolean {
+  if (!esperado) return false;
+  const valores = flattenValores(valor);
+  if (valores.length === 0) return false;
+  return valores.some(v => v === esperado);
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
     "scripts": {
         "dev": "next dev -p 3001",
         "build": "next build",
-        "start": "next start"
+        "start": "next start",
+        "test": "../backend/node_modules/.bin/ts-node --esm ./lib/__tests__/atributos.test.ts"
     },
     "dependencies": {
         "axios": "^1.8.4",


### PR DESCRIPTION
## Resumo
- ajusta a tela de produto para reconhecer a flag `multivalorado`, armazenar arrays e renderizar o `MultiSelect`, garantindo visibilidade e validação corretas dos atributos condicionados
- adiciona utilitários compartilhados para normalizar valores dinâmicos, reaproveitando-os nos componentes e cobrindo-os com um teste automatizado simples
- refatora o serviço de produtos no backend para aceitar coleções nos atributos, atualiza as validações e amplia a suíte de testes para cobrir cenários multivalorados

## Testes
- `npm test` (frontend)
- `SKIP_PRISMA_GENERATE=1 npm test` (backend)
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_68d21af144a88330a8f9722745737c0f