### PR TITLE
feat: implementar sugestões de NCM com auto-complete

### DIFF
--- a/backend/src/controllers/siscomex.controller.ts
+++ b/backend/src/controllers/siscomex.controller.ts
@@ -11,6 +11,41 @@ const atributoLegacyService = new AtributoLegacyService();
 const ncmLegacyService = new NcmLegacyService();
 
 /**
+ * GET /api/siscomex/ncm/sugestoes
+ * Lista sugestões de NCM filtrando por prefixo
+ */
+export async function listarSugestoesNcm(req: Request, res: Response) {
+  try {
+    const prefixo = ((req.query.prefixo as string) || '').trim();
+
+    if (!prefixo) {
+      return res.status(400).json({ error: 'Prefixo é obrigatório' });
+    }
+
+    if (!/^\d+$/.test(prefixo)) {
+      return res.status(400).json({ error: 'Prefixo deve conter apenas números' });
+    }
+
+    if (prefixo.length < 4 || prefixo.length > 7) {
+      return res.status(400).json({ error: 'Prefixo deve ter entre 4 e 7 dígitos' });
+    }
+
+    const sugestoes = await ncmLegacyService.buscarSugestoes(prefixo);
+
+    return res.status(200).json({
+      sucesso: true,
+      total: sugestoes.length,
+      dados: sugestoes
+    });
+  } catch (error: unknown) {
+    logger.error('Erro ao listar sugestões de NCM:', error);
+    return res.status(500).json({
+      error: error instanceof Error ? error.message : 'Erro interno ao listar sugestões de NCM'
+    });
+  }
+}
+
+/**
  * GET /api/siscomex/produtos
  * Consulta produtos no SISCOMEX
  */

--- a/backend/src/routes/siscomex.routes.ts
+++ b/backend/src/routes/siscomex.routes.ts
@@ -7,6 +7,7 @@ import {
   detalharVersaoProduto,
   exportarCatalogo,
   consultarAtributosPorNcm,
+  listarSugestoesNcm,
   verificarStatus
 } from '../controllers/siscomex.controller';
 import { authMiddleware } from '../middlewares/auth.middleware';
@@ -15,6 +16,28 @@ const router = Router();
 
 // Todas as rotas SISCOMEX são protegidas por autenticação
 router.use(authMiddleware);
+
+/**
+ * @swagger
+ * /api/v1/siscomex/ncm/sugestoes:
+ *   get:
+ *     summary: Lista sugestões de códigos NCM
+ *     tags: [SISCOMEX]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: prefixo
+ *         required: true
+ *         schema:
+ *           type: string
+ *           minLength: 4
+ *           maxLength: 7
+ *     responses:
+ *       200:
+ *         description: Lista de sugestões de NCM
+ */
+router.get('/ncm/sugestoes', listarSugestoesNcm);
 
 /**
  * @swagger

--- a/backend/src/services/__tests__/ncm-legacy.service.test.ts
+++ b/backend/src/services/__tests__/ncm-legacy.service.test.ts
@@ -25,6 +25,31 @@ describe('NcmLegacyService', () => {
     expect(resultado).toEqual({ descricao: 'Produto Teste', unidadeMedida: 'KG' })
   })
 
+  it('buscarSugestoes deve retornar lista do legado', async () => {
+    mockedLegacy.$queryRaw.mockResolvedValueOnce([
+      { codigo: '12345678', descricao: 'Teste 1' },
+      { codigo: '12349999', descricao: 'Teste 2' }
+    ])
+
+    const service = new NcmLegacyService()
+    const resultado = await service.buscarSugestoes('1234')
+
+    expect(mockedLegacy.$queryRaw).toHaveBeenCalledTimes(1)
+    expect(resultado).toEqual([
+      { codigo: '12345678', descricao: 'Teste 1' },
+      { codigo: '12349999', descricao: 'Teste 2' }
+    ])
+  })
+
+  it('buscarSugestoes deve retornar lista vazia quando não houver dados', async () => {
+    mockedLegacy.$queryRaw.mockResolvedValueOnce([])
+
+    const service = new NcmLegacyService()
+    const resultado = await service.buscarSugestoes('9876')
+
+    expect(resultado).toEqual([])
+  })
+
   it('sincronizarNcm deve gravar no cache', async () => {
     mockedLegacy.$queryRaw.mockResolvedValueOnce([
       { descricao: 'Produto Teste', unidade_medida: 'KG' }

--- a/backend/src/services/ncm-legacy.service.ts
+++ b/backend/src/services/ncm-legacy.service.ts
@@ -6,6 +6,11 @@ export interface NcmInfo {
   unidadeMedida: string | null
 }
 
+export interface NcmSugestao {
+  codigo: string
+  descricao: string | null
+}
+
 export class NcmLegacyService {
   async buscarNcm(codigo: string): Promise<NcmInfo | null> {
     const rows = await legacyPrisma.$queryRaw<Array<{
@@ -21,6 +26,24 @@ export class NcmLegacyService {
     if (rows.length === 0) return null
     const row = rows[0]
     return { descricao: row.descricao, unidadeMedida: row.unidade_medida }
+  }
+
+  async buscarSugestoes(prefixo: string): Promise<NcmSugestao[]> {
+    const likePattern = `${prefixo}%`
+    const rows = await legacyPrisma.$queryRaw<Array<{
+      codigo: string
+      descricao: string | null
+    }>>(Prisma.sql`
+      SELECT t.codigo, t.mercadoria AS descricao
+        FROM tec t
+       WHERE CHAR_LENGTH(t.codigo) = 8
+         AND t.sequencial = 1
+         AND t.codigo LIKE ${likePattern}
+       ORDER BY t.codigo ASC
+       LIMIT 10
+    `)
+
+    return rows.map(row => ({ codigo: row.codigo, descricao: row.descricao }))
   }
 
   async sincronizarNcm(codigo: string): Promise<NcmInfo | null> {

--- a/frontend/hooks/useDebounce.ts
+++ b/frontend/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+
+export function useDebounce<T>(value: T, delay = 1000): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}
+
+export default useDebounce

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -271,7 +271,7 @@ export default function ProdutoPage() {
     setNcmSugestoes([]);
     setMostrarSugestoesNcm(false);
     setCarregandoSugestoesNcm(false);
-  }, [debouncedNcm, addToast]);
+  }, [debouncedNcm]);
 
   function handleValor(codigo: string, valor: string | string[]) {
     setValores(prev => ({ ...prev, [codigo]: valor }));
@@ -683,7 +683,7 @@ export default function ProdutoPage() {
         </h1>
       </div>
 
-      <Card className="mb-6">
+      <Card className="mb-6 overflow-visible">
         <div className="grid grid-cols-4 gap-4">
           {isNew && !workingCatalog ? (
             <Select


### PR DESCRIPTION
## Resumo
- cria endpoint autenticado para sugerir NCM com filtro por prefixo e sequencial no legado
- adiciona testes unitários cobrindo o novo fluxo de sugestões no NcmLegacyService
- implementa auto-complete de NCM na tela de produtos com debounce reutilizável e dropdown de seleção

## Testes
- npm test *(falha: requer variável DATABASE_URL e banco acessível para o prisma migrate)*
- DATABASE_URL="mysql://user:pass@localhost:3306/db" npm run build
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d6e8d16d748330a5cea598705b5aab