### PR TITLE
feat: habilitar clonagem na listagem de produtos

### DIFF
--- a/backend/src/controllers/produto.controller.ts
+++ b/backend/src/controllers/produto.controller.ts
@@ -103,3 +103,27 @@ export async function removerProduto(req: Request, res: Response) {
     res.status(500).json({ error: error.message });
   }
 }
+
+export async function clonarProduto(req: Request, res: Response) {
+  try {
+    const id = Number(req.params.id);
+    const produto = await produtoService.clonar(
+      id,
+      req.body,
+      req.user!.superUserId
+    );
+    res.status(201).json(produto);
+  } catch (error: any) {
+    if (error instanceof ValidationError) {
+      return res.status(400).json({ error: error.message, details: error.details });
+    }
+    if (error.message?.includes('não encontrado')) {
+      return res.status(404).json({ error: error.message });
+    }
+    if (error.message?.includes('Catálogo de destino')) {
+      return res.status(400).json({ error: error.message });
+    }
+    logger.error('Erro ao clonar produto:', error);
+    res.status(500).json({ error: error.message });
+  }
+}

--- a/backend/src/routes/produto.routes.ts
+++ b/backend/src/routes/produto.routes.ts
@@ -5,11 +5,16 @@ import {
   obterProduto,
   criarProduto,
   atualizarProduto,
-  removerProduto
+  removerProduto,
+  clonarProduto
 } from '../controllers/produto.controller';
 import { authMiddleware } from '../middlewares/auth.middleware';
 import { validate } from '../middlewares/validate.middleware';
-import { createProdutoSchema, updateProdutoSchema } from '../validators/produto.validator';
+import {
+  createProdutoSchema,
+  updateProdutoSchema,
+  cloneProdutoSchema
+} from '../validators/produto.validator';
 
 const router = Router();
 
@@ -19,6 +24,7 @@ router.get('/', listarProdutos);
 router.get('/:id', obterProduto);
 router.post('/', validate(createProdutoSchema), criarProduto);
 router.put('/:id', validate(updateProdutoSchema), atualizarProduto);
+router.post('/:id/clonar', validate(cloneProdutoSchema), clonarProduto);
 router.delete('/:id', removerProduto);
 
 export default router;

--- a/backend/src/validators/produto.validator.ts
+++ b/backend/src/validators/produto.validator.ts
@@ -46,3 +46,14 @@ export const updateProdutoSchema = z.object({
   })).optional(),
   atualizadoPor: z.string().optional()
 });
+
+export const cloneProdutoSchema = z.object({
+  catalogoId: z.number().int(),
+  denominacao: z.string().max(100).min(1),
+  codigosInternos: z
+    .array(z.string().max(50))
+    .optional()
+    .refine(arr => !arr || new Set(arr).size === arr.length, {
+      message: 'Códigos internos duplicados não são permitidos'
+    })
+});


### PR DESCRIPTION
## Resumo
- criar rota, controlador e validações para clonar produtos reaproveitando dados e permitindo novos SKUs
- atualizar a listagem de produtos com botão e modal para escolher catálogo e definir nome/novos SKUs

## Testes
- npm run build:all

------
https://chatgpt.com/codex/tasks/task_e_68dc2ad7ad4c83308dd3f60182f8abf4