### PR TITLE
fix: alinhar modelo de mensagens e atualizar notificacoes

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
 
   subUsuarios SubUsuario[]
   certificados Certificado[]
+  mensagens    Mensagem[]
 
   @@map("comex")
 }
@@ -93,6 +94,10 @@ enum CatalogoAmbiente {
   PRODUCAO
 }
 
+enum MensagemCategoria {
+  ATUALIZACAO_SISCOMEX
+}
+
 model Catalogo {
   id               Int            @id @default(autoincrement()) @map("id")
   nome             String         @map("nome")
@@ -109,6 +114,23 @@ model Catalogo {
 
   @@unique([superUserId, cpf_cnpj], name: "uk_superuser_cpf_cnpj")
   @@map("catalogo")
+}
+
+model Mensagem {
+  id          Int                @id @default(autoincrement()) @map("id")
+  superUserId Int                @map("super_user_id")
+  superUser   User               @relation(fields: [superUserId], references: [id])
+  titulo      String             @map("titulo")
+  conteudo    String             @map("conteudo")
+  categoria   MensagemCategoria  @map("categoria")
+  lida        Boolean            @default(false) @map("lida")
+  criadaEm    DateTime           @default(now()) @map("criada_em")
+  lidaEm      DateTime?          @map("lida_em")
+
+  @@map("mensagem")
+  @@index([superUserId], map: "idx_mensagem_super_user_id")
+  @@index([lida], map: "idx_mensagem_lida")
+  @@index([criadaEm], map: "idx_mensagem_criada_em")
 }
 
 model Pais {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -16,6 +16,7 @@ import usuarioRoutes from './routes/usuario.routes';
 import { Router } from 'express';
 import { API_PREFIX } from './config';
 import uploadRoutes from './routes/upload.routes';
+import mensagemRoutes from './routes/mensagem.routes';
 
 const app = express();
 
@@ -54,6 +55,9 @@ apiRouter.use('/usuarios', usuarioRoutes);
 
 // Rotas de painel (protegidas)
 apiRouter.use('/dashboard', dashboardRoutes);
+
+// Rotas de mensagens (protegidas)
+apiRouter.use('/mensagens', mensagemRoutes);
 
 // Middleware de autenticação para rotas protegidas
 apiRouter.use('/protected', authMiddleware, (req, res) => {

--- a/backend/src/controllers/mensagem.controller.ts
+++ b/backend/src/controllers/mensagem.controller.ts
@@ -1,0 +1,155 @@
+// backend/src/controllers/mensagem.controller.ts
+import { Request, Response } from 'express';
+import { MensagemService, MensagemStatusFiltro } from '../services/mensagem.service';
+import { MensagemCategoria } from '@prisma/client';
+import { logger } from '../utils/logger';
+
+const mensagemService = new MensagemService();
+
+const STATUS_VALIDOS: MensagemStatusFiltro[] = ['TODAS', 'LIDAS', 'NAO_LIDAS'];
+
+function normalizarStatus(valor: unknown): MensagemStatusFiltro {
+  if (!valor) return 'TODAS';
+  const normalizado = Array.isArray(valor) ? valor[0] : valor;
+  if (typeof normalizado !== 'string') {
+    return 'TODAS';
+  }
+  const maiusculo = normalizado.toUpperCase() as MensagemStatusFiltro;
+  return STATUS_VALIDOS.includes(maiusculo) ? maiusculo : 'TODAS';
+}
+
+function normalizarCategoria(valor: unknown): MensagemCategoria | undefined {
+  if (!valor) return undefined;
+  const normalizado = Array.isArray(valor) ? valor[0] : valor;
+  if (typeof normalizado !== 'string') {
+    return undefined;
+  }
+  if (Object.values(MensagemCategoria).includes(normalizado as MensagemCategoria)) {
+    return normalizado as MensagemCategoria;
+  }
+  return undefined;
+}
+
+function parsePositiveNumber(valor: unknown): number | undefined {
+  if (!valor) return undefined;
+  const normalizado = Array.isArray(valor) ? valor[0] : valor;
+  if (typeof normalizado !== 'string' && typeof normalizado !== 'number') {
+    return undefined;
+  }
+  const numero = Number(normalizado);
+  if (Number.isNaN(numero) || numero < 0) {
+    return undefined;
+  }
+  return Math.floor(numero);
+}
+
+export async function listarMensagens(req: Request, res: Response) {
+  try {
+    const superUserId = req.user?.superUserId;
+    if (!superUserId) {
+      return res.status(401).json({ error: 'Usuário não autenticado' });
+    }
+
+    const status = normalizarStatus(req.query.status);
+    const limit = parsePositiveNumber(req.query.limit);
+    const offset = parsePositiveNumber(req.query.offset);
+    const categoria = normalizarCategoria(req.query.categoria);
+
+    const resultado = await mensagemService.listar(
+      superUserId,
+      status,
+      limit,
+      offset,
+      categoria,
+    );
+
+    return res.json(resultado);
+  } catch (error) {
+    logger.error('Erro ao listar mensagens', error);
+    return res.status(500).json({ error: 'Erro ao listar mensagens' });
+  }
+}
+
+export async function obterMensagem(req: Request, res: Response) {
+  try {
+    const superUserId = req.user?.superUserId;
+    if (!superUserId) {
+      return res.status(401).json({ error: 'Usuário não autenticado' });
+    }
+
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) {
+      return res.status(400).json({ error: 'Identificador inválido' });
+    }
+
+    const mensagem = await mensagemService.buscarPorId(superUserId, id);
+    if (!mensagem) {
+      return res.status(404).json({ error: 'Mensagem não encontrada' });
+    }
+
+    return res.json(mensagem);
+  } catch (error) {
+    logger.error('Erro ao buscar mensagem', error);
+    return res.status(500).json({ error: 'Erro ao buscar mensagem' });
+  }
+}
+
+export async function marcarMensagemComoLida(req: Request, res: Response) {
+  try {
+    const superUserId = req.user?.superUserId;
+    if (!superUserId) {
+      return res.status(401).json({ error: 'Usuário não autenticado' });
+    }
+
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) {
+      return res.status(400).json({ error: 'Identificador inválido' });
+    }
+
+    const mensagem = await mensagemService.marcarComoLida(superUserId, id);
+    if (!mensagem) {
+      return res.status(404).json({ error: 'Mensagem não encontrada' });
+    }
+
+    return res.json(mensagem);
+  } catch (error) {
+    logger.error('Erro ao marcar mensagem como lida', error);
+    return res.status(500).json({ error: 'Erro ao atualizar mensagem' });
+  }
+}
+
+export async function resumoNaoLidas(req: Request, res: Response) {
+  try {
+    const superUserId = req.user?.superUserId;
+    if (!superUserId) {
+      return res.status(401).json({ error: 'Usuário não autenticado' });
+    }
+
+    const limit = parsePositiveNumber(req.query.limit) ?? 5;
+    const resultado = await mensagemService.resumoNaoLidas(superUserId, limit);
+    return res.json(resultado);
+  } catch (error) {
+    logger.error('Erro ao obter resumo de mensagens não lidas', error);
+    return res.status(500).json({ error: 'Erro ao carregar resumo de mensagens' });
+  }
+}
+
+export async function contarNaoLidas(req: Request, res: Response) {
+  try {
+    const superUserId = req.user?.superUserId;
+    if (!superUserId) {
+      return res.status(401).json({ error: 'Usuário não autenticado' });
+    }
+
+    const total = await mensagemService.contarNaoLidas(superUserId);
+    return res.json({ total });
+  } catch (error) {
+    logger.error('Erro ao contar mensagens não lidas', error);
+    return res.status(500).json({ error: 'Erro ao contar mensagens não lidas' });
+  }
+}
+
+export function listarCategorias(_: Request, res: Response) {
+  const categorias = mensagemService.listarCategorias();
+  return res.json({ categorias });
+}

--- a/backend/src/routes/mensagem.routes.ts
+++ b/backend/src/routes/mensagem.routes.ts
@@ -1,0 +1,24 @@
+// backend/src/routes/mensagem.routes.ts
+import { Router } from 'express';
+import { authMiddleware } from '../middlewares/auth.middleware';
+import {
+  listarMensagens,
+  obterMensagem,
+  marcarMensagemComoLida,
+  resumoNaoLidas,
+  contarNaoLidas,
+  listarCategorias,
+} from '../controllers/mensagem.controller';
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.get('/categorias', listarCategorias);
+router.get('/resumo-nao-lidas', resumoNaoLidas);
+router.get('/contagem-nao-lidas', contarNaoLidas);
+router.get('/', listarMensagens);
+router.get('/:id', obterMensagem);
+router.patch('/:id/lida', marcarMensagemComoLida);
+
+export default router;

--- a/backend/src/services/mensagem.service.ts
+++ b/backend/src/services/mensagem.service.ts
@@ -1,0 +1,124 @@
+// backend/src/services/mensagem.service.ts
+import { catalogoPrisma } from '../utils/prisma';
+import { Mensagem as MensagemModel, MensagemCategoria, Prisma } from '@prisma/client';
+
+export type MensagemStatusFiltro = 'TODAS' | 'LIDAS' | 'NAO_LIDAS';
+
+export interface MensagemDTO {
+  id: number;
+  titulo: string;
+  conteudo: string;
+  categoria: MensagemCategoria;
+  lida: boolean;
+  criadaEm: Date;
+  lidaEm?: Date | null;
+}
+
+export interface ListaMensagensResultado {
+  total: number;
+  mensagens: MensagemDTO[];
+}
+
+export class MensagemService {
+  private mapToDTO(mensagem: MensagemModel): MensagemDTO {
+    return {
+      id: mensagem.id,
+      titulo: mensagem.titulo,
+      conteudo: mensagem.conteudo,
+      categoria: mensagem.categoria,
+      lida: mensagem.lida,
+      criadaEm: mensagem.criadaEm,
+      lidaEm: mensagem.lidaEm ?? null,
+    };
+  }
+
+  async listar(
+    superUserId: number,
+    status: MensagemStatusFiltro = 'TODAS',
+    limit?: number,
+    offset?: number,
+    categoria?: MensagemCategoria,
+  ): Promise<ListaMensagensResultado> {
+    const where: Prisma.MensagemWhereInput = {
+      superUserId,
+    };
+
+    if (status === 'LIDAS') {
+      where.lida = true;
+    } else if (status === 'NAO_LIDAS') {
+      where.lida = false;
+    }
+
+    if (categoria) {
+      where.categoria = categoria;
+    }
+
+    const [mensagens, total] = await Promise.all([
+      catalogoPrisma.mensagem.findMany({
+        where,
+        orderBy: { criadaEm: 'desc' },
+        skip: offset,
+        take: limit,
+      }),
+      catalogoPrisma.mensagem.count({ where }),
+    ]);
+
+    return {
+      total,
+      mensagens: mensagens.map((mensagem) => this.mapToDTO(mensagem)),
+    };
+  }
+
+  async resumoNaoLidas(superUserId: number, limit: number = 5): Promise<ListaMensagensResultado> {
+    return this.listar(superUserId, 'NAO_LIDAS', limit, 0);
+  }
+
+  async contarNaoLidas(superUserId: number): Promise<number> {
+    return catalogoPrisma.mensagem.count({
+      where: {
+        superUserId,
+        lida: false,
+      },
+    });
+  }
+
+  async buscarPorId(superUserId: number, id: number): Promise<MensagemDTO | null> {
+    const mensagem = await catalogoPrisma.mensagem.findFirst({
+      where: { id, superUserId },
+    });
+
+    if (!mensagem) {
+      return null;
+    }
+
+    return this.mapToDTO(mensagem);
+  }
+
+  async marcarComoLida(superUserId: number, id: number): Promise<MensagemDTO | null> {
+    const mensagem = await catalogoPrisma.mensagem.findFirst({
+      where: { id, superUserId },
+    });
+
+    if (!mensagem) {
+      return null;
+    }
+
+    if (mensagem.lida) {
+      return this.mapToDTO(mensagem);
+    }
+
+    const atualizada = await catalogoPrisma.mensagem.update({
+      where: { id },
+      data: {
+        lida: true,
+        lidaEm: new Date(),
+      },
+    });
+
+    return this.mapToDTO(atualizada);
+  }
+
+  listarCategorias(): MensagemCategoria[] {
+    return Object.values(MensagemCategoria);
+  }
+}

--- a/docs/sql/2024-05-15_adiciona_mensagem.sql
+++ b/docs/sql/2024-05-15_adiciona_mensagem.sql
@@ -1,0 +1,16 @@
+-- Script incremental para criação da tabela de mensagens
+CREATE TABLE IF NOT EXISTS mensagem (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    super_user_id INT UNSIGNED NOT NULL,
+    titulo VARCHAR(255) NOT NULL,
+    conteudo TEXT NOT NULL,
+    categoria ENUM('ATUALIZACAO_SISCOMEX') NOT NULL DEFAULT 'ATUALIZACAO_SISCOMEX',
+    lida TINYINT(1) NOT NULL DEFAULT 0,
+    criada_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    lida_em DATETIME NULL,
+    PRIMARY KEY (id),
+    INDEX idx_mensagem_super_user_id (super_user_id),
+    INDEX idx_mensagem_lida (lida),
+    INDEX idx_mensagem_criada_em (criada_em),
+    CONSTRAINT fk_mensagem_super_user FOREIGN KEY (super_user_id) REFERENCES comex(idv32)
+);

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import {
   FileText, PieChart, Briefcase, Users,
-  ChevronLeft, ChevronRight, User, Key, UserCog
+  ChevronLeft, ChevronRight, User, Key, UserCog, Mail
 } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -71,6 +71,13 @@ export function Sidebar({ onToggle, isCollapsed }: SidebarProps) {
       label: 'Painel',
       subItems: [
         { label: 'Painel', href: '/', showWhenExpanded: true },
+      ],
+    },
+    {
+      icon: <Mail size={20} />,
+      label: 'Mensagens',
+      subItems: [
+        { label: 'Mensagens', href: '/mensagens', showWhenExpanded: true },
       ],
     },
     {

--- a/frontend/contexts/MessagesContext.tsx
+++ b/frontend/contexts/MessagesContext.tsx
@@ -1,0 +1,197 @@
+// frontend/contexts/MessagesContext.tsx
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, ReactNode } from 'react';
+import api from '@/lib/api';
+import { useAuth } from './AuthContext';
+
+export type MensagemCategoria = 'ATUALIZACAO_SISCOMEX';
+export type MensagemStatusFiltro = 'TODAS' | 'LIDAS' | 'NAO_LIDAS';
+
+export interface Mensagem {
+  id: number;
+  titulo: string;
+  conteudo: string;
+  categoria: MensagemCategoria;
+  lida: boolean;
+  criadaEm: string;
+  lidaEm?: string | null;
+}
+
+interface ListaMensagensResponse {
+  total: number;
+  mensagens: Mensagem[];
+}
+
+interface MessagesContextValue {
+  unreadMessages: Mensagem[];
+  unreadCount: number;
+  isLoadingUnread: boolean;
+  refreshUnread: () => Promise<void>;
+  listMessages: (
+    status?: MensagemStatusFiltro,
+    categoria?: MensagemCategoria,
+    limit?: number,
+    offset?: number,
+  ) => Promise<ListaMensagensResponse>;
+  getMessage: (id: number) => Promise<Mensagem>;
+  markAsRead: (id: number) => Promise<Mensagem | null>;
+  listarCategorias: () => Promise<MensagemCategoria[]>;
+}
+
+const MessagesContext = createContext<MessagesContextValue | undefined>(undefined);
+
+export function MessagesProvider({ children }: { children: ReactNode }) {
+  const { token } = useAuth();
+  const [unreadMessages, setUnreadMessages] = useState<Mensagem[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [isLoadingUnread, setIsLoadingUnread] = useState(false);
+  const isMountedRef = useRef(true);
+  const pollingRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const listMessages = useCallback<MessagesContextValue['listMessages']>(
+    async (status = 'TODAS', categoria, limit, offset) => {
+      const params: Record<string, string | number> = {};
+      if (status) params.status = status;
+      if (categoria) params.categoria = categoria;
+      if (typeof limit === 'number') params.limit = limit;
+      if (typeof offset === 'number') params.offset = offset;
+
+      const { data } = await api.get<ListaMensagensResponse>('/mensagens', { params });
+      return data;
+    },
+    [],
+  );
+
+  const getMessage = useCallback(async (id: number) => {
+    const { data } = await api.get<Mensagem>(`/mensagens/${id}`);
+    return data;
+  }, []);
+
+  const refreshUnread = useCallback(async () => {
+    if (!token) {
+      if (isMountedRef.current) {
+        setUnreadMessages([]);
+        setUnreadCount(0);
+      }
+      return;
+    }
+
+    setIsLoadingUnread(true);
+    try {
+      const { data } = await api.get<ListaMensagensResponse>('/mensagens/resumo-nao-lidas', {
+        params: { limit: 5 },
+      });
+      if (!isMountedRef.current) return;
+      setUnreadMessages(data.mensagens);
+      setUnreadCount(data.total);
+    } catch (error) {
+      if (!isMountedRef.current) return;
+      setUnreadMessages([]);
+      setUnreadCount(0);
+      console.error('Erro ao carregar mensagens não lidas:', error);
+    } finally {
+      if (isMountedRef.current) {
+        setIsLoadingUnread(false);
+      }
+    }
+  }, [token]);
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+  }, []);
+
+  const markAsRead = useCallback(async (id: number) => {
+    try {
+      const { data } = await api.patch<Mensagem>(`/mensagens/${id}/lida`);
+      await refreshUnread();
+      return data;
+    } catch (error) {
+      console.error('Erro ao marcar mensagem como lida:', error);
+      throw error;
+    }
+  }, [refreshUnread]);
+
+  const listarCategorias = useCallback(async () => {
+    const { data } = await api.get<{ categorias: MensagemCategoria[] }>('/mensagens/categorias');
+    return data.categorias;
+  }, []);
+
+  useEffect(() => {
+    if (!token) {
+      stopPolling();
+      if (isMountedRef.current) {
+        setUnreadMessages([]);
+        setUnreadCount(0);
+      }
+      return;
+    }
+
+    refreshUnread();
+
+    stopPolling();
+    const interval = setInterval(() => {
+      refreshUnread();
+    }, 30000);
+    pollingRef.current = interval;
+
+    let visibilityHandler: (() => void) | undefined;
+    if (typeof document !== 'undefined') {
+      visibilityHandler = () => {
+        if (document.visibilityState === 'visible') {
+          refreshUnread();
+        }
+      };
+      document.addEventListener('visibilitychange', visibilityHandler);
+    }
+
+    return () => {
+      stopPolling();
+      if (visibilityHandler && typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', visibilityHandler);
+      }
+    };
+  }, [token, refreshUnread, stopPolling]);
+
+  const value = useMemo<MessagesContextValue>(() => ({
+    unreadMessages,
+    unreadCount,
+    isLoadingUnread,
+    refreshUnread,
+    listMessages,
+    getMessage,
+    markAsRead,
+    listarCategorias,
+  }), [
+    unreadMessages,
+    unreadCount,
+    isLoadingUnread,
+    refreshUnread,
+    listMessages,
+    getMessage,
+    markAsRead,
+    listarCategorias,
+  ]);
+
+  return (
+    <MessagesContext.Provider value={value}>
+      {children}
+    </MessagesContext.Provider>
+  );
+}
+
+export function useMessages(): MessagesContextValue {
+  const context = useContext(MessagesContext);
+  if (!context) {
+    throw new Error('useMessages deve ser utilizado dentro de um MessagesProvider');
+  }
+  return context;
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -4,6 +4,7 @@ import { AppProps } from 'next/app'
 import Head from 'next/head'
 import { AuthProvider, useAuth } from '@/contexts/AuthContext'
 import { WorkingCatalogProvider } from '@/contexts/WorkingCatalogContext'
+import { MessagesProvider } from '@/contexts/MessagesContext'
 import { ToastProvider } from '@/components/ui/ToastContext'
 import { LoadingScreen } from '@/components/ui/LoadingScreen'
 import { PageTransition } from '@/components/ui/PageTransition'
@@ -27,10 +28,12 @@ export default function App(props: AppProps) {
       </Head>
       <AuthProvider>
         <WorkingCatalogProvider>
-          <ToastProvider>
-            <PageTransition />
-            <AppContent {...props} />
-          </ToastProvider>
+          <MessagesProvider>
+            <ToastProvider>
+              <PageTransition />
+              <AppContent {...props} />
+            </ToastProvider>
+          </MessagesProvider>
         </WorkingCatalogProvider>
       </AuthProvider>
     </>

--- a/frontend/pages/mensagens/index.tsx
+++ b/frontend/pages/mensagens/index.tsx
@@ -1,0 +1,281 @@
+// frontend/pages/mensagens/index.tsx
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+import { Mensagem, MensagemCategoria, MensagemStatusFiltro, useMessages } from '@/contexts/MessagesContext';
+
+const STATUS_FILTROS: { label: string; valor: MensagemStatusFiltro }[] = [
+  { label: 'Não lidas', valor: 'NAO_LIDAS' },
+  { label: 'Lidas', valor: 'LIDAS' },
+  { label: 'Todas', valor: 'TODAS' },
+];
+
+const CATEGORIA_LABELS: Record<MensagemCategoria, string> = {
+  ATUALIZACAO_SISCOMEX: 'Atualização do SISCOMEX',
+};
+
+export default function MensagensPage() {
+  const router = useRouter();
+  const { listMessages, getMessage, markAsRead, listarCategorias } = useMessages();
+
+  const [mensagens, setMensagens] = useState<Mensagem[]>([]);
+  const [mensagemSelecionada, setMensagemSelecionada] = useState<Mensagem | null>(null);
+  const [statusFiltro, setStatusFiltro] = useState<MensagemStatusFiltro>('NAO_LIDAS');
+  const [categoriaFiltro, setCategoriaFiltro] = useState<MensagemCategoria | 'TODAS'>('TODAS');
+  const [categoriasDisponiveis, setCategoriasDisponiveis] = useState<MensagemCategoria[]>([]);
+  const [carregandoLista, setCarregandoLista] = useState(true);
+  const [carregandoDetalhe, setCarregandoDetalhe] = useState(false);
+
+  const categoriaOptions = useMemo(() => {
+    const items = categoriasDisponiveis.map((categoria) => ({
+      valor: categoria,
+      label: CATEGORIA_LABELS[categoria] ?? categoria,
+    }));
+    return [{ valor: 'TODAS' as const, label: 'Todas as categorias' }, ...items];
+  }, [categoriasDisponiveis]);
+
+  useEffect(() => {
+    async function carregarCategorias() {
+      try {
+        const categorias = await listarCategorias();
+        setCategoriasDisponiveis(categorias);
+      } catch (error) {
+        console.error('Erro ao carregar categorias de mensagens:', error);
+      }
+    }
+
+    carregarCategorias();
+  }, [listarCategorias]);
+
+  useEffect(() => {
+    async function carregarMensagens() {
+      setCarregandoLista(true);
+      try {
+        const categoria = categoriaFiltro === 'TODAS' ? undefined : categoriaFiltro;
+        const resposta = await listMessages(statusFiltro, categoria);
+        setMensagens(resposta.mensagens);
+
+        if (resposta.mensagens.length > 0) {
+          setMensagemSelecionada((atual) => {
+            if (!atual) {
+              return resposta.mensagens[0];
+            }
+            const encontrada = resposta.mensagens.find((msg) => msg.id === atual.id);
+            return encontrada ?? resposta.mensagens[0];
+          });
+        } else {
+          setMensagemSelecionada((atual) => {
+            if (atual && statusFiltro === 'NAO_LIDAS') {
+              return atual;
+            }
+            return null;
+          });
+        }
+      } catch (error) {
+        console.error('Erro ao carregar mensagens:', error);
+        setMensagens([]);
+      } finally {
+        setCarregandoLista(false);
+      }
+    }
+
+    carregarMensagens();
+  }, [listMessages, statusFiltro, categoriaFiltro]);
+
+  useEffect(() => {
+    const { mensagem } = router.query;
+    if (!router.isReady || !mensagem) {
+      return;
+    }
+
+    const mensagemId = Number(mensagem);
+    if (Number.isNaN(mensagemId)) {
+      return;
+    }
+
+    selecionarMensagem(mensagemId, { atualizarUrl: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady, router.query.mensagem]);
+
+  async function selecionarMensagem(id: number, options: { atualizarUrl?: boolean } = {}) {
+    setCarregandoDetalhe(true);
+    try {
+      let mensagem = mensagens.find((item) => item.id === id) ?? null;
+
+      if (!mensagem) {
+        try {
+          mensagem = await getMessage(id);
+        } catch (error) {
+          console.error('Erro ao carregar mensagem selecionada:', error);
+        }
+      }
+
+      if (mensagem && !mensagem.lida) {
+        try {
+          const mensagemAtualizada = await markAsRead(id);
+          if (mensagemAtualizada) {
+            mensagem = mensagemAtualizada;
+          }
+        } catch (error) {
+          console.error('Erro ao marcar mensagem como lida:', error);
+        }
+
+        setMensagens((prev) => {
+          if (statusFiltro === 'NAO_LIDAS') {
+            return prev.filter((item) => item.id !== id);
+          }
+          return prev.map((item) => (item.id === id ? { ...item, lida: true, lidaEm: mensagem?.lidaEm ?? new Date().toISOString() } : item));
+        });
+      }
+
+      setMensagemSelecionada(mensagem ?? null);
+
+      if (options.atualizarUrl !== false) {
+        router.replace(
+          {
+            pathname: '/mensagens',
+            query: { mensagem: id },
+          },
+          undefined,
+          { shallow: true },
+        );
+      }
+    } finally {
+      setCarregandoDetalhe(false);
+    }
+  }
+
+  const dataFormatada = useMemo(() => {
+    if (!mensagemSelecionada) return '';
+    return new Intl.DateTimeFormat('pt-BR', {
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(mensagemSelecionada.criadaEm));
+  }, [mensagemSelecionada]);
+
+  return (
+    <DashboardLayout title="Mensagens">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 h-full">
+        <section className="lg:col-span-1 bg-[#151921] border border-gray-800 rounded-lg flex flex-col">
+          <header className="border-b border-gray-800 px-4 py-3">
+            <h2 className="text-lg font-semibold text-gray-100">Caixa de entrada</h2>
+            <p className="text-sm text-gray-400">Gerencie as mensagens importantes para o seu catálogo.</p>
+          </header>
+
+          <div className="px-4 py-3 border-b border-gray-800 flex flex-wrap gap-2">
+            {STATUS_FILTROS.map((filtro) => (
+              <button
+                key={filtro.valor}
+                onClick={() => setStatusFiltro(filtro.valor)}
+                className={`px-3 py-1.5 text-sm rounded-full border transition-colors ${
+                  statusFiltro === filtro.valor
+                    ? 'border-[#f59e0b] text-[#f59e0b] bg-[#2a2f3a]'
+                    : 'border-transparent bg-[#1e232d] text-gray-300 hover:text-white'
+                }`}
+              >
+                {filtro.label}
+              </button>
+            ))}
+          </div>
+
+          {categoriaOptions.length > 1 && (
+            <div className="px-4 pb-3">
+              <label htmlFor="categoriaFiltro" className="block text-xs uppercase tracking-wide text-gray-400 mb-1">
+                Categoria
+              </label>
+              <select
+                id="categoriaFiltro"
+                className="w-full bg-[#1e232d] border border-gray-700 rounded-md px-3 py-2 text-sm text-gray-200 focus:outline-none focus:border-[#f59e0b]"
+                value={categoriaFiltro}
+                onChange={(event) => setCategoriaFiltro(event.target.value as MensagemCategoria | 'TODAS')}
+              >
+                {categoriaOptions.map((categoria) => (
+                  <option key={categoria.valor} value={categoria.valor}>
+                    {categoria.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div className="flex-1 overflow-y-auto">
+            {carregandoLista ? (
+              <p className="text-sm text-gray-400 px-4 py-6">Carregando mensagens...</p>
+            ) : mensagens.length === 0 ? (
+              <p className="text-sm text-gray-400 px-4 py-6">
+                {statusFiltro === 'NAO_LIDAS'
+                  ? 'Nenhuma mensagem não lida encontrada.'
+                  : 'Nenhuma mensagem encontrada para o filtro selecionado.'}
+              </p>
+            ) : (
+              <ul className="divide-y divide-gray-800">
+                {mensagens.map((mensagem) => {
+                  const selecionada = mensagemSelecionada?.id === mensagem.id;
+                  return (
+                    <li key={mensagem.id}>
+                      <button
+                        onClick={() => selecionarMensagem(mensagem.id)}
+                        className={`w-full text-left px-4 py-4 transition-colors ${
+                          selecionada ? 'bg-[#2a2f3a] border-l-4 border-[#f59e0b]' : 'hover:bg-[#1e232d]'
+                        }`}
+                      >
+                        <div className="flex items-center justify-between">
+                          <h3 className="text-sm font-semibold text-gray-100 truncate">{mensagem.titulo}</h3>
+                          <span className="text-xs text-gray-400 ml-4">
+                            {new Date(mensagem.criadaEm).toLocaleDateString('pt-BR')}
+                          </span>
+                        </div>
+                        <p className="text-xs text-gray-400 mt-2 overflow-hidden text-ellipsis whitespace-normal max-h-12 leading-5">
+                          {mensagem.conteudo}
+                        </p>
+                        <span className="inline-block mt-3 text-[11px] uppercase tracking-wide text-[#f59e0b] bg-[#2a2f3a] px-2 py-1 rounded-full">
+                          {CATEGORIA_LABELS[mensagem.categoria] ?? mensagem.categoria}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </section>
+
+        <section className="lg:col-span-2 bg-[#151921] border border-gray-800 rounded-lg p-6 flex flex-col">
+          {carregandoDetalhe ? (
+            <div className="flex-1 flex items-center justify-center">
+              <p className="text-gray-400">Carregando mensagem...</p>
+            </div>
+          ) : !mensagemSelecionada ? (
+            <div className="flex-1 flex items-center justify-center text-center">
+              <div>
+                <h2 className="text-lg font-semibold text-gray-200">Selecione uma mensagem</h2>
+                <p className="text-sm text-gray-400 mt-2">
+                  Escolha uma mensagem na lista ao lado para visualizar os detalhes.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <article className="flex-1 overflow-y-auto">
+              <header className="border-b border-gray-800 pb-4 mb-4">
+                <span className="inline-block text-[11px] uppercase tracking-wide text-[#f59e0b] bg-[#2a2f3a] px-2 py-1 rounded-full">
+                  {CATEGORIA_LABELS[mensagemSelecionada.categoria] ?? mensagemSelecionada.categoria}
+                </span>
+                <h1 className="text-2xl font-semibold text-gray-100 mt-3">{mensagemSelecionada.titulo}</h1>
+                <p className="text-sm text-gray-400 mt-2">{dataFormatada}</p>
+              </header>
+
+              <div className="prose prose-invert max-w-none">
+                <p className="whitespace-pre-line text-gray-200 leading-relaxed">
+                  {mensagemSelecionada.conteudo}
+                </p>
+              </div>
+            </article>
+          )}
+        </section>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/scripts_banco_catalogo_produtos.sql
+++ b/scripts_banco_catalogo_produtos.sql
@@ -35,6 +35,23 @@ CREATE TABLE IF NOT EXISTS certificado (
     INDEX idx_cert_super_user_id (super_user_id)
 );
 
+-- Tabela de mensagens para notificações dos superusuários
+CREATE TABLE IF NOT EXISTS mensagem (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    super_user_id INT UNSIGNED NOT NULL,
+    titulo VARCHAR(255) NOT NULL,
+    conteudo TEXT NOT NULL,
+    categoria ENUM('ATUALIZACAO_SISCOMEX') NOT NULL DEFAULT 'ATUALIZACAO_SISCOMEX',
+    lida TINYINT(1) NOT NULL DEFAULT 0,
+    criada_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    lida_em DATETIME NULL,
+    PRIMARY KEY (id),
+    INDEX idx_mensagem_super_user_id (super_user_id),
+    INDEX idx_mensagem_lida (lida),
+    INDEX idx_mensagem_criada_em (criada_em),
+    CONSTRAINT fk_mensagem_super_user FOREIGN KEY (super_user_id) REFERENCES comex(idv32)
+);
+
 CREATE TABLE IF NOT EXISTS catalogo (
     id INT UNSIGNED NOT NULL AUTO_INCREMENT,
     nome VARCHAR(255) NOT NULL,


### PR DESCRIPTION
## Resumo
- alinhar o modelo Prisma de mensagens ao banco legada, adicionando relação com o superusuário e índices equivalentes
- ativar atualização periódica e ao voltar o foco da aba para sincronizar notificações de mensagens não lidas no frontend

## Testes
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_68dc2dd803448330aa6de144461727e0