### PR TITLE
Alinha importação de produtos ao DDL consolidado

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   subUsuarios SubUsuario[]
   certificados Certificado[]
   mensagens    Mensagem[]
+  importacoes  ImportacaoProduto[]
 
   @@map("comex")
 }
@@ -62,7 +63,8 @@ model UsuarioCatalogo {
   criadoEm    DateTime @default(now()) @map("criado_em")
   atualizadoEm DateTime @updatedAt @map("atualizado_em")
 
-  permissoes UsuarioPermissao[]
+  permissoes  UsuarioPermissao[]
+  importacoes ImportacaoProduto[]
 
   @@map("usuario_catalogo")
 }
@@ -111,6 +113,7 @@ model Catalogo {
   certificado     Certificado?   @relation(fields: [certificadoId], references: [id])
   produtos         Produto[]
   operadoresEstrangeiros OperadorEstrangeiro[]
+  importacoes      ImportacaoProduto[]
 
   @@unique([superUserId, cpf_cnpj], name: "uk_superuser_cpf_cnpj")
   @@map("catalogo")
@@ -231,6 +234,23 @@ enum OperadorEstrangeiroStatus {
   ATIVADO
   DESATIVADO
 }
+
+enum ImportacaoSituacao {
+  EM_ANDAMENTO
+  CONCLUIDA
+}
+
+enum ImportacaoResultado {
+  PENDENTE
+  SUCESSO
+  ATENCAO
+}
+
+enum ImportacaoProdutoItemResultado {
+  SUCESSO
+  ATENCAO
+  ERRO
+}
 // Enum de status de Produto
 enum ProdutoStatus {
   PENDENTE
@@ -299,6 +319,7 @@ model Produto {
   atributos                 ProdutoAtributos[]
   codigosInternos           CodigoInternoProduto[]
   operadoresEstrangeiros    OperadorEstrangeiroProduto[]
+  importacaoItens           ImportacaoProdutoItem[] @relation("ProdutoImportacaoItens")
 
   @@index([ncmCodigo], name: "idx_ncm")
   @@index([catalogoId], name: "idx_catalogo")
@@ -341,4 +362,52 @@ model OperadorEstrangeiroProduto {
   produto               Produto               @relation(fields: [produtoId], references: [id], onDelete: Cascade)
 
   @@map("operador_estrangeiro_produto")
+}
+
+model ImportacaoProduto {
+  id                 Int                 @id @default(autoincrement()) @map("id")
+  superUserId        Int                 @map("super_user_id")
+  usuarioCatalogoId  Int?                @map("usuario_catalogo_id")
+  catalogoId         Int                 @map("catalogo_id")
+  modalidade         String              @map("modalidade")
+  nomeArquivo        String?             @map("nome_arquivo")
+  situacao           ImportacaoSituacao  @default(EM_ANDAMENTO) @map("situacao")
+  resultado          ImportacaoResultado @default(PENDENTE) @map("resultado")
+  totalRegistros     Int                 @default(0) @map("total_registros")
+  totalCriados       Int                 @default(0) @map("total_criados")
+  totalComAtencao    Int                 @default(0) @map("total_com_atencao")
+  totalComErro       Int                 @default(0) @map("total_com_erro")
+  iniciadoEm         DateTime            @default(now()) @map("iniciado_em")
+  finalizadoEm       DateTime?           @map("finalizado_em")
+
+  superUser        User                @relation(fields: [superUserId], references: [id])
+  catalogo         Catalogo         @relation(fields: [catalogoId], references: [id])
+  usuarioCatalogo  UsuarioCatalogo? @relation(fields: [usuarioCatalogoId], references: [id])
+  itens            ImportacaoProdutoItem[]
+
+  @@index([superUserId], map: "idx_importacao_super_user")
+  @@index([catalogoId], map: "idx_importacao_catalogo")
+  @@map("importacao_produto")
+}
+
+model ImportacaoProdutoItem {
+  id                   Int                               @id @default(autoincrement()) @map("id")
+  importacaoId         Int                               @map("importacao_id")
+  linhaPlanilha        Int                               @map("linha_planilha")
+  ncm                  String?                           @map("ncm")
+  denominacao          String?                           @map("denominacao")
+  codigosInternos      String?                           @map("codigos_internos") @db.Text
+  resultado            ImportacaoProdutoItemResultado    @map("resultado")
+  mensagens            Json?                             @map("mensagens")
+  possuiErroImpeditivo Boolean                           @default(false) @map("possui_erro_impeditivo")
+  possuiAlerta         Boolean                           @default(false) @map("possui_alerta")
+  produtoId            Int?                              @map("produto_id")
+  criadoEm             DateTime                          @default(now()) @map("criado_em")
+
+  importacao ImportacaoProduto @relation(fields: [importacaoId], references: [id], onDelete: Cascade)
+  produto    Produto?          @relation("ProdutoImportacaoItens", fields: [produtoId], references: [id])
+
+  @@index([importacaoId], map: "idx_importacao_item_importacao")
+  @@index([resultado], map: "idx_importacao_item_resultado")
+  @@map("importacao_produto_item")
 }

--- a/backend/scripts/parse_excel.py
+++ b/backend/scripts/parse_excel.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Utilitário simples para converter a primeira planilha de um arquivo XLSX em uma matriz JSON."""
+import json
+import sys
+import zipfile
+import xml.etree.ElementTree as ET
+from typing import Dict, List
+
+NAMESPACE = {'s': 'http://schemas.openxmlformats.org/spreadsheetml/2006/main'}
+
+
+def _coluna_para_indice(ref: str) -> int:
+    colunas = ''.join(ch for ch in ref if ch.isalpha())
+    indice = 0
+    for ch in colunas:
+        indice = indice * 26 + (ord(ch.upper()) - ord('A') + 1)
+    return indice - 1 if indice > 0 else 0
+
+
+def _ler_shared_strings(arquivo_zip: zipfile.ZipFile) -> List[str]:
+    if 'xl/sharedStrings.xml' not in arquivo_zip.namelist():
+        return []
+    conteudo = arquivo_zip.read('xl/sharedStrings.xml')
+    raiz = ET.fromstring(conteudo)
+    valores: List[str] = []
+    for si in raiz.findall('s:si', NAMESPACE):
+        texto = ''.join(t.text or '' for t in si.findall('.//s:t', NAMESPACE))
+        valores.append(texto)
+    return valores
+
+
+def _resolver_valor(celula: ET.Element, shared_strings: List[str]) -> str:
+    tipo = celula.get('t')
+    if tipo == 'inlineStr':
+        texto = celula.find('s:is/s:t', NAMESPACE)
+        return (texto.text or '') if texto is not None else ''
+
+    valor = celula.find('s:v', NAMESPACE)
+    if valor is None or valor.text is None:
+        return ''
+
+    if tipo == 's':
+        indice = int(valor.text)
+        if 0 <= indice < len(shared_strings):
+            return shared_strings[indice]
+        return ''
+
+    return valor.text
+
+
+def _selecionar_planilha(arquivo_zip: zipfile.ZipFile) -> str:
+    for nome in arquivo_zip.namelist():
+        if nome.startswith('xl/worksheets/sheet') and nome.endswith('.xml'):
+            return nome
+    raise ValueError('Não foi possível localizar uma planilha válida no arquivo enviado')
+
+
+def ler_planilha(caminho_arquivo: str) -> List[List[str]]:
+    with zipfile.ZipFile(caminho_arquivo, 'r') as arquivo_zip:
+        shared_strings = _ler_shared_strings(arquivo_zip)
+        planilha = _selecionar_planilha(arquivo_zip)
+        dados = arquivo_zip.read(planilha)
+        raiz = ET.fromstring(dados)
+        sheet_data = raiz.find('s:sheetData', NAMESPACE)
+        if sheet_data is None:
+            return []
+
+        linhas: List[List[str]] = []
+        for linha in sheet_data.findall('s:row', NAMESPACE):
+            valores: Dict[int, str] = {}
+            for celula in linha.findall('s:c', NAMESPACE):
+                referencia = celula.get('r') or ''
+                indice = _coluna_para_indice(referencia)
+                valores[indice] = _resolver_valor(celula, shared_strings)
+
+            if valores:
+                tamanho = max(valores.keys()) + 1
+                linha_formatada = [''] * tamanho
+                for indice, valor in valores.items():
+                    linha_formatada[indice] = valor
+            else:
+                linha_formatada = []
+            linhas.append(linha_formatada)
+        return linhas
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit('Uso: parse_excel.py <arquivo.xlsx>')
+
+    caminho = sys.argv[1]
+    try:
+        linhas = ler_planilha(caminho)
+    except Exception as erro:  # pragma: no cover - captura genérica para retorno ao Node
+        sys.stderr.write(str(erro))
+        raise
+    sys.stdout.write(json.dumps(linhas, ensure_ascii=False))
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/src/controllers/produto-importacao.controller.ts
+++ b/backend/src/controllers/produto-importacao.controller.ts
@@ -1,0 +1,90 @@
+import { Request, Response } from 'express';
+import { ProdutoImportacaoService } from '../services/produto-importacao.service';
+import { logger } from '../utils/logger';
+
+const produtoImportacaoService = new ProdutoImportacaoService();
+
+export async function importarProdutosPorPlanilha(req: Request, res: Response) {
+  try {
+    const { catalogoId, modalidade, arquivo } = req.body as {
+      catalogoId?: number | string;
+      modalidade?: string;
+      arquivo?: { nome?: string; conteudoBase64?: string };
+    };
+
+    if (!catalogoId) {
+      return res.status(400).json({ error: 'Catálogo é obrigatório' });
+    }
+
+    const catalogoIdNumber = Number(catalogoId);
+    if (Number.isNaN(catalogoIdNumber)) {
+      return res.status(400).json({ error: 'Catálogo inválido' });
+    }
+
+    const importacao = await produtoImportacaoService.importarPlanilhaExcel(
+      {
+        catalogoId: catalogoIdNumber,
+        modalidade,
+        arquivo: {
+          nome: arquivo?.nome ?? '',
+          conteudoBase64: arquivo?.conteudoBase64 ?? ''
+        }
+      },
+      req.user!.superUserId,
+      req.user?.id
+    );
+
+    return res.status(201).json(importacao);
+  } catch (error) {
+    logger.error('Erro ao importar produtos via Excel:', error);
+    if (error instanceof Error) {
+      if (error.message.includes('Catálogo não encontrado')) {
+        return res.status(404).json({ error: error.message });
+      }
+      if (
+        error.message.includes('Arquivo Excel não foi enviado') ||
+        error.message.includes('Formato inválido') ||
+        error.message.includes('Conteúdo do arquivo inválido') ||
+        error.message.includes('não possui dados')
+      ) {
+        return res.status(400).json({ error: error.message });
+      }
+    }
+    return res.status(500).json({ error: 'Erro interno ao importar planilha' });
+  }
+}
+
+export async function listarImportacoes(req: Request, res: Response) {
+  try {
+    const importacoes = await produtoImportacaoService.listarImportacoes(
+      req.user!.superUserId
+    );
+    return res.json(importacoes);
+  } catch (error) {
+    logger.error('Erro ao listar importações:', error);
+    return res.status(500).json({ error: 'Erro ao listar importações' });
+  }
+}
+
+export async function obterDetalhesImportacao(req: Request, res: Response) {
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) {
+      return res.status(400).json({ error: 'Identificador inválido' });
+    }
+
+    const importacao = await produtoImportacaoService.obterImportacao(
+      id,
+      req.user!.superUserId
+    );
+
+    if (!importacao) {
+      return res.status(404).json({ error: 'Importação não encontrada' });
+    }
+
+    return res.json(importacao);
+  } catch (error) {
+    logger.error('Erro ao obter detalhes da importação:', error);
+    return res.status(500).json({ error: 'Erro ao obter detalhes da importação' });
+  }
+}

--- a/backend/src/routes/produto.routes.ts
+++ b/backend/src/routes/produto.routes.ts
@@ -8,6 +8,11 @@ import {
   removerProduto,
   clonarProduto
 } from '../controllers/produto.controller';
+import {
+  importarProdutosPorPlanilha,
+  listarImportacoes,
+  obterDetalhesImportacao
+} from '../controllers/produto-importacao.controller';
 import { authMiddleware } from '../middlewares/auth.middleware';
 import { validate } from '../middlewares/validate.middleware';
 import {
@@ -19,6 +24,10 @@ import {
 const router = Router();
 
 router.use(authMiddleware);
+
+router.get('/importacoes', listarImportacoes);
+router.get('/importacoes/:id', obterDetalhesImportacao);
+router.post('/importacao', importarProdutosPorPlanilha);
 
 router.get('/', listarProdutos);
 router.get('/:id', obterProduto);

--- a/backend/src/services/produto-importacao.service.ts
+++ b/backend/src/services/produto-importacao.service.ts
@@ -1,0 +1,335 @@
+import { ImportacaoProdutoItemResultado, ImportacaoResultado, Prisma } from '@prisma/client';
+import { promises as fs } from 'fs';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { catalogoPrisma } from '../utils/prisma';
+import { logger } from '../utils/logger';
+import { ProdutoService } from './produto.service';
+import { ValidationError } from '../types/validation-error';
+
+const execFileAsync = promisify(execFile);
+
+export interface ArquivoImportacao {
+  nome: string;
+  conteudoBase64: string;
+}
+
+export interface NovaImportacaoPlanilhaInput {
+  catalogoId: number;
+  modalidade?: string;
+  arquivo: ArquivoImportacao;
+}
+
+interface MensagensItemImportacao {
+  impeditivos: string[];
+  atencao: string[];
+}
+
+export class ProdutoImportacaoService {
+  private produtoService = new ProdutoService();
+
+  async importarPlanilhaExcel(
+    dados: NovaImportacaoPlanilhaInput,
+    superUserId: number,
+    usuarioLegacyId?: number
+  ) {
+    const catalogo = await catalogoPrisma.catalogo.findFirst({
+      where: { id: dados.catalogoId, superUserId }
+    });
+
+    if (!catalogo) {
+      throw new Error('Catálogo não encontrado para o superusuário informado');
+    }
+
+    let usuarioCatalogoId: number | null = null;
+    if (usuarioLegacyId) {
+      const usuarioCatalogo = await catalogoPrisma.usuarioCatalogo.findFirst({
+        where: {
+          legacyId: usuarioLegacyId,
+          superUserId
+        }
+      });
+
+      usuarioCatalogoId = usuarioCatalogo?.id ?? null;
+    }
+
+    if (!dados.arquivo?.conteudoBase64 || !dados.arquivo?.nome) {
+      throw new Error('Arquivo Excel não foi enviado');
+    }
+
+    if (!dados.arquivo.nome.toLowerCase().endsWith('.xlsx')) {
+      throw new Error('Formato inválido: envie um arquivo .xlsx');
+    }
+
+    const buffer = this.converterBase64(dados.arquivo.conteudoBase64);
+    if (!buffer?.length) {
+      throw new Error('Conteúdo do arquivo inválido');
+    }
+
+    const importacao = await catalogoPrisma.importacaoProduto.create({
+      data: {
+        superUserId,
+        usuarioCatalogoId,
+        catalogoId: dados.catalogoId,
+        modalidade: (dados.modalidade || 'IMPORTACAO').toUpperCase(),
+        nomeArquivo: dados.arquivo.nome,
+        situacao: 'EM_ANDAMENTO',
+        resultado: 'PENDENTE'
+      }
+    });
+
+    let totalRegistros = 0;
+    let totalCriados = 0;
+    let totalComAtencao = 0;
+    let totalComErro = 0;
+
+    try {
+      const linhas = await this.lerPlanilha(buffer);
+      if (!linhas || linhas.length <= 1) {
+        throw new Error('A planilha não possui dados para importação');
+      }
+
+      const modalidade = (dados.modalidade || 'IMPORTACAO').toUpperCase();
+
+      for (let index = 1; index < linhas.length; index++) {
+        const linha = linhas[index];
+        const linhaPlanilha = index + 1;
+        const celulas = Array.isArray(linha) ? linha : [];
+        const ncmBruta = (celulas[0] ?? '').toString().trim();
+        const denominacaoBruta = (celulas[1] ?? '').toString().trim();
+        const codigosBrutos = (celulas[2] ?? '').toString().trim();
+
+        if (!ncmBruta && !denominacaoBruta && !codigosBrutos) {
+          continue;
+        }
+
+        totalRegistros += 1;
+
+        const mensagens: MensagensItemImportacao = {
+          impeditivos: [],
+          atencao: []
+        };
+
+        const ncmNormalizada = this.normalizarNcm(ncmBruta, mensagens.impeditivos);
+        const denominacao = denominacaoBruta;
+
+        if (!denominacao) {
+          mensagens.impeditivos.push('Nome (obrigatório) não informado');
+        }
+
+        let codigosInternos: string[] | undefined;
+        if (!codigosBrutos) {
+          mensagens.atencao.push('Códigos internos / SKU não informados');
+        } else {
+          const partes = codigosBrutos
+            .split(',')
+            .map(p => p.trim())
+            .filter(Boolean);
+
+          const invalidos = partes.filter(p => !/^\d+$/.test(p));
+          if (invalidos.length > 0) {
+            mensagens.atencao.push('Campo Códigos internos / SKU mal formatado');
+          } else if (partes.length > 0) {
+            codigosInternos = partes;
+          }
+        }
+
+        if (ncmNormalizada) {
+          const ncmCache = await catalogoPrisma.ncmCache.findUnique({
+            where: { codigo: ncmNormalizada }
+          });
+          if (!ncmCache) {
+            mensagens.impeditivos.push('NCM não encontrada');
+          }
+        }
+
+        let resultadoItem: ImportacaoProdutoItemResultado = 'ERRO';
+        let produtoId: number | null = null;
+
+        if (mensagens.impeditivos.length === 0 && ncmNormalizada && denominacao) {
+          try {
+            const produto = await this.produtoService.criar(
+              {
+                ncmCodigo: ncmNormalizada,
+                modalidade,
+                catalogoId: dados.catalogoId,
+                denominacao,
+                descricao: denominacao,
+                codigosInternos
+              },
+              superUserId
+            );
+
+            produtoId = produto.id;
+            totalCriados += 1;
+            if (mensagens.atencao.length > 0) {
+              resultadoItem = 'ATENCAO';
+              totalComAtencao += 1;
+            } else {
+              resultadoItem = 'SUCESSO';
+            }
+          } catch (error) {
+            if (error instanceof ValidationError) {
+              mensagens.impeditivos.push(
+                error.details.map(d => `${d.field}: ${d.message}`).join('; ')
+              );
+            } else {
+              const mensagemErro =
+                error instanceof Error ? error.message : 'Erro desconhecido na criação do produto';
+              mensagens.impeditivos.push(`Erro ao criar produto: ${mensagemErro}`);
+            }
+            resultadoItem = 'ERRO';
+            totalComErro += 1;
+          }
+        } else {
+          totalComErro += 1;
+        }
+
+        await catalogoPrisma.importacaoProdutoItem.create({
+          data: {
+            importacaoId: importacao.id,
+            linhaPlanilha,
+            ncm: ncmNormalizada ?? null,
+            denominacao: denominacao || null,
+            codigosInternos: codigosBrutos || null,
+            resultado: resultadoItem,
+            mensagens: mensagens as unknown as Prisma.InputJsonValue,
+            possuiErroImpeditivo: mensagens.impeditivos.length > 0,
+            possuiAlerta: mensagens.atencao.length > 0,
+            produtoId
+          }
+        });
+      }
+
+      const resultadoFinal: ImportacaoResultado =
+        totalComErro > 0 || totalComAtencao > 0 ? 'ATENCAO' : 'SUCESSO';
+
+      await catalogoPrisma.importacaoProduto.update({
+        where: { id: importacao.id },
+        data: {
+          situacao: 'CONCLUIDA',
+          resultado: resultadoFinal,
+          totalRegistros,
+          totalCriados,
+          totalComAtencao,
+          totalComErro,
+          finalizadoEm: new Date()
+        }
+      });
+
+      return this.obterImportacao(importacao.id, superUserId);
+    } catch (error) {
+      logger.error('Falha ao processar planilha de importação:', error);
+
+      await catalogoPrisma.importacaoProduto.update({
+        where: { id: importacao.id },
+        data: {
+          situacao: 'CONCLUIDA',
+          resultado: 'ATENCAO',
+          totalRegistros,
+          totalCriados,
+          totalComAtencao,
+          totalComErro: totalComErro || (totalRegistros - totalCriados),
+          finalizadoEm: new Date()
+        }
+      });
+
+      throw error;
+    }
+  }
+
+  async listarImportacoes(superUserId: number) {
+    return catalogoPrisma.importacaoProduto.findMany({
+      where: { superUserId },
+      orderBy: { iniciadoEm: 'desc' },
+      include: {
+        catalogo: {
+          select: {
+            id: true,
+            nome: true,
+            numero: true,
+            cpf_cnpj: true
+          }
+        }
+      }
+    });
+  }
+
+  async obterImportacao(id: number, superUserId: number) {
+    return catalogoPrisma.importacaoProduto.findFirst({
+      where: { id, superUserId },
+      include: {
+        catalogo: {
+          select: {
+            id: true,
+            nome: true,
+            numero: true,
+            cpf_cnpj: true
+          }
+        },
+        itens: {
+          orderBy: { linhaPlanilha: 'asc' }
+        }
+      }
+    });
+  }
+
+  private converterBase64(base64: string): Buffer {
+    const limpo = base64.replace(/^data:[^;]+;base64,/, '').trim();
+    return Buffer.from(limpo, 'base64');
+  }
+
+  private normalizarNcm(ncm: string, erros: string[]): string | null {
+    if (!ncm) {
+      erros.push('NCM (obrigatório) não informada');
+      return null;
+    }
+
+    const semEspacos = ncm.replace(/\s+/g, '');
+    const apenasDigitos = semEspacos.replace(/\D/g, '');
+
+    if (apenasDigitos.length !== 8) {
+      erros.push('NCM não formatada corretamente');
+      return null;
+    }
+
+    if (apenasDigitos !== semEspacos) {
+      erros.push('NCM não formatada corretamente');
+      return null;
+    }
+
+    return apenasDigitos;
+  }
+
+  private async lerPlanilha(buffer: Buffer): Promise<string[][]> {
+    const dirTemporario = await fs.mkdtemp(join(tmpdir(), 'import-produto-'));
+    const arquivoTemporario = join(dirTemporario, `${randomUUID()}.xlsx`);
+    const caminhoScript = resolve(process.cwd(), 'backend/scripts/parse_excel.py');
+
+    try {
+      await fs.writeFile(arquivoTemporario, buffer);
+      const { stdout } = await this.executarPython(caminhoScript, arquivoTemporario);
+      const conteudo = stdout.trim();
+      if (!conteudo) {
+        throw new Error('Falha ao interpretar o conteúdo da planilha');
+      }
+      return JSON.parse(conteudo);
+    } finally {
+      await fs.rm(dirTemporario, { recursive: true, force: true });
+    }
+  }
+
+  private async executarPython(script: string, arquivo: string) {
+    try {
+      return await execFileAsync('python3', [script, arquivo], { maxBuffer: 10 * 1024 * 1024 });
+    } catch (error: any) {
+      if (error?.code === 'ENOENT') {
+        return execFileAsync('python', [script, arquivo], { maxBuffer: 10 * 1024 * 1024 });
+      }
+      throw error;
+    }
+  }
+}

--- a/docs/sql/2025-02-15_importacao_produto.sql
+++ b/docs/sql/2025-02-15_importacao_produto.sql
@@ -1,0 +1,43 @@
+-- Cria tabelas para controle de importação de produtos via planilha
+CREATE TABLE IF NOT EXISTS importacao_produto (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    super_user_id INT UNSIGNED NOT NULL,
+    usuario_catalogo_id INT UNSIGNED NULL,
+    catalogo_id INT UNSIGNED NOT NULL,
+    modalidade VARCHAR(50) NOT NULL,
+    nome_arquivo VARCHAR(255),
+    situacao ENUM('EM_ANDAMENTO', 'CONCLUIDA') NOT NULL DEFAULT 'EM_ANDAMENTO',
+    resultado ENUM('PENDENTE', 'SUCESSO', 'ATENCAO') NOT NULL DEFAULT 'PENDENTE',
+    total_registros INT UNSIGNED NOT NULL DEFAULT 0,
+    total_criados INT UNSIGNED NOT NULL DEFAULT 0,
+    total_com_atencao INT UNSIGNED NOT NULL DEFAULT 0,
+    total_com_erro INT UNSIGNED NOT NULL DEFAULT 0,
+    iniciado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    finalizado_em DATETIME NULL,
+    PRIMARY KEY (id),
+    INDEX idx_importacao_super_user (super_user_id),
+    INDEX idx_importacao_catalogo (catalogo_id),
+    -- Integridade com superusuário será validada pela aplicação
+    CONSTRAINT fk_importacao_produto_catalogo FOREIGN KEY (catalogo_id) REFERENCES catalogo(id),
+    CONSTRAINT fk_importacao_produto_usuario FOREIGN KEY (usuario_catalogo_id) REFERENCES usuario_catalogo(id)
+);
+
+CREATE TABLE IF NOT EXISTS importacao_produto_item (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    importacao_id INT UNSIGNED NOT NULL,
+    linha_planilha INT NOT NULL,
+    ncm VARCHAR(8),
+    denominacao VARCHAR(255),
+    codigos_internos TEXT,
+    resultado ENUM('SUCESSO', 'ATENCAO', 'ERRO') NOT NULL,
+    mensagens JSON NULL,
+    possui_erro_impeditivo TINYINT(1) NOT NULL DEFAULT 0,
+    possui_alerta TINYINT(1) NOT NULL DEFAULT 0,
+    produto_id INT UNSIGNED NULL,
+    criado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    INDEX idx_importacao_item_importacao (importacao_id),
+    INDEX idx_importacao_item_resultado (resultado),
+    CONSTRAINT fk_importacao_produto_item_importacao FOREIGN KEY (importacao_id) REFERENCES importacao_produto(id) ON DELETE CASCADE,
+    CONSTRAINT fk_importacao_produto_item_produto FOREIGN KEY (produto_id) REFERENCES produto(id)
+);

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -106,7 +106,7 @@ export function Sidebar({ onToggle, isCollapsed }: SidebarProps) {
       label: 'Automação',
       subItems: [
         { label: 'Automação', hideWhenExpanded: true },
-        { label: 'Importar produto', href: '/automacao/importar-produto' },
+        { label: 'Importar Produto', href: '/automacao/importar-produto' },
         // { label: 'Preencher Atributos em Massa', href: '/automacao/preencher-atributos-em-massa' },
         // { label: 'Ajuste de Produtos em Massa', href: '/automacao/ajuste-de-produtos-em-massa' },
         // { label: 'Definir Valor de Atributo Padrão', href: '/automacao/definir-valor-de-atributo-padrao' },

--- a/frontend/pages/automacao/importar-produto/[id].tsx
+++ b/frontend/pages/automacao/importar-produto/[id].tsx
@@ -1,0 +1,353 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+import { Breadcrumb } from '@/components/ui/Breadcrumb';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { PageLoader } from '@/components/ui/PageLoader';
+import api from '@/lib/api';
+import { formatCPFOrCNPJ } from '@/lib/validation';
+import { useToast } from '@/components/ui/ToastContext';
+import { AlertTriangle, ArrowLeft, CheckCircle, ChevronDown, ChevronUp } from 'lucide-react';
+
+interface MensagensItem {
+  impeditivos?: string[];
+  atencao?: string[];
+}
+
+interface ImportacaoItem {
+  id: number;
+  linhaPlanilha: number;
+  ncm?: string | null;
+  denominacao?: string | null;
+  codigosInternos?: string | null;
+  resultado: 'SUCESSO' | 'ATENCAO' | 'ERRO';
+  mensagens?: MensagensItem | null;
+  possuiErroImpeditivo: boolean;
+  possuiAlerta: boolean;
+  produtoId?: number | null;
+}
+
+interface ImportacaoDetalhe {
+  id: number;
+  catalogo: {
+    id: number;
+    nome: string;
+    numero: number;
+    cpf_cnpj?: string | null;
+  };
+  nomeArquivo?: string | null;
+  modalidade: string;
+  situacao: 'EM_ANDAMENTO' | 'CONCLUIDA';
+  resultado: 'PENDENTE' | 'SUCESSO' | 'ATENCAO';
+  totalRegistros: number;
+  totalCriados: number;
+  totalComAtencao: number;
+  totalComErro: number;
+  iniciadoEm: string;
+  finalizadoEm?: string | null;
+  itens: ImportacaoItem[];
+}
+
+function formatarData(data?: string | null) {
+  if (!data) return '-';
+  const objeto = new Date(data);
+  if (Number.isNaN(objeto.getTime())) return '-';
+  return `${objeto.toLocaleDateString('pt-BR')} ${objeto.toLocaleTimeString('pt-BR')}`;
+}
+
+function traduzResultado(resultado: ImportacaoDetalhe['resultado']) {
+  switch (resultado) {
+    case 'SUCESSO':
+      return 'Sucesso';
+    case 'ATENCAO':
+      return 'Atenção';
+    case 'PENDENTE':
+      return 'Pendente';
+  }
+}
+
+function obterClasseResultado(resultado: ImportacaoDetalhe['resultado']) {
+  switch (resultado) {
+    case 'SUCESSO':
+      return 'bg-emerald-500/10 text-emerald-300 border border-emerald-500/40';
+    case 'ATENCAO':
+      return 'bg-amber-500/10 text-amber-300 border border-amber-500/40';
+    case 'PENDENTE':
+      return 'bg-slate-500/10 text-slate-300 border border-slate-500/40';
+    default:
+      return 'bg-slate-700/40 text-slate-200 border border-slate-600/40';
+  }
+}
+
+function traduzModalidade(modalidade: string) {
+  return modalidade === 'EXPORTACAO' ? 'Exportação' : 'Importação';
+}
+
+function traduzSituacao(situacao: ImportacaoDetalhe['situacao']) {
+  return situacao === 'CONCLUIDA' ? 'Concluída' : 'Em andamento';
+}
+
+function obterMensagem(lista?: string[]) {
+  if (!lista || lista.length === 0) return null;
+  return (
+    <ul className="mt-2 list-disc pl-5 text-sm text-gray-200">
+      {lista.map((mensagem, indice) => (
+        <li key={indice}>{mensagem}</li>
+      ))}
+    </ul>
+  );
+}
+
+export default function ImportacaoDetalhePage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const { addToast } = useToast();
+  const [detalhe, setDetalhe] = useState<ImportacaoDetalhe | null>(null);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState<string | null>(null);
+  const [errosAbertos, setErrosAbertos] = useState(true);
+  const [sucessosAbertos, setSucessosAbertos] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    const carregar = async () => {
+      try {
+        setCarregando(true);
+        const resposta = await api.get<ImportacaoDetalhe>(`/produtos/importacoes/${id}`);
+        setDetalhe(resposta.data);
+        setErro(null);
+      } catch (error: any) {
+        console.error('Erro ao carregar importação', error);
+        const mensagem = error.response?.data?.error || 'Não foi possível carregar os detalhes.';
+        setErro(mensagem);
+        addToast(mensagem, 'error');
+      } finally {
+        setCarregando(false);
+      }
+    };
+    carregar();
+  }, [id, addToast]);
+
+  const itensErro = useMemo(
+    () => detalhe?.itens.filter(item => item.resultado === 'ERRO') ?? [],
+    [detalhe]
+  );
+  const itensSucesso = useMemo(
+    () => detalhe?.itens.filter(item => item.resultado !== 'ERRO') ?? [],
+    [detalhe]
+  );
+
+  if (carregando && !detalhe) {
+    return (
+      <DashboardLayout title="Detalhes da Importação">
+        <PageLoader message="Carregando detalhes da importação..." />
+      </DashboardLayout>
+    );
+  }
+
+  if (erro) {
+    return (
+      <DashboardLayout title="Detalhes da Importação">
+        <Breadcrumb
+          items={[
+            { label: 'Automação', href: '/automacao/importar-produto' },
+            { label: 'Importar Produto', href: '/automacao/importar-produto' },
+            { label: 'Detalhes' }
+          ]}
+        />
+        <Card className="border border-red-500/40 bg-red-500/5 text-red-300">
+          <p>{erro}</p>
+          <Button className="mt-4" onClick={() => router.push('/automacao/importar-produto')}>
+            Voltar para importações
+          </Button>
+        </Card>
+      </DashboardLayout>
+    );
+  }
+
+  if (!detalhe) return null;
+
+  return (
+    <DashboardLayout title="Detalhes da Importação">
+      <Breadcrumb
+        items={[
+          { label: 'Automação', href: '/automacao/importar-produto' },
+          { label: 'Importar Produto', href: '/automacao/importar-produto' },
+          { label: `Importação #${detalhe.id}` }
+        ]}
+      />
+
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <Button
+          variant="outline"
+          className="flex items-center gap-2 text-gray-300 hover:text-white"
+          onClick={() => router.push('/automacao/importar-produto')}
+        >
+          <ArrowLeft size={16} />
+          Voltar para importações
+        </Button>
+      </div>
+
+      <Card className="mb-6">
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div>
+            <h1 className="text-2xl font-semibold text-white">Importação #{detalhe.id}</h1>
+            <p className="mt-1 text-sm text-gray-400">
+              {detalhe.nomeArquivo ? `Arquivo ${detalhe.nomeArquivo}` : 'Arquivo não informado'}
+            </p>
+            <p className="mt-1 text-sm text-gray-400">
+              Catálogo {detalhe.catalogo.nome} · Nº {detalhe.catalogo.numero} ·{' '}
+              {formatCPFOrCNPJ(detalhe.catalogo.cpf_cnpj || '')}
+            </p>
+            <p className="mt-2 text-sm text-gray-400">
+              Modalidade {traduzModalidade(detalhe.modalidade)} · Situação {traduzSituacao(detalhe.situacao)}
+            </p>
+            <div className="mt-3">
+              <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-sm font-medium ${obterClasseResultado(detalhe.resultado)}`}>
+                Resultado: {traduzResultado(detalhe.resultado)}
+              </span>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3 text-center text-sm text-gray-300">
+            <div className="rounded-lg border border-slate-700 bg-slate-800/40 p-4">
+              <p className="text-xs uppercase tracking-wide text-gray-400">Registros analisados</p>
+              <p className="mt-1 text-2xl font-semibold text-white">{detalhe.totalRegistros}</p>
+            </div>
+            <div className="rounded-lg border border-emerald-600/40 bg-emerald-600/10 p-4">
+              <p className="text-xs uppercase tracking-wide text-emerald-300">Produtos criados</p>
+              <p className="mt-1 text-2xl font-semibold text-emerald-200">{detalhe.totalCriados}</p>
+            </div>
+            <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-4">
+              <p className="text-xs uppercase tracking-wide text-amber-300">Com atenção</p>
+              <p className="mt-1 text-2xl font-semibold text-amber-200">{detalhe.totalComAtencao}</p>
+            </div>
+            <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-4">
+              <p className="text-xs uppercase tracking-wide text-red-300">Com erro</p>
+              <p className="mt-1 text-2xl font-semibold text-red-200">{detalhe.totalComErro}</p>
+            </div>
+          </div>
+        </div>
+        <div className="mt-4 grid gap-3 text-sm text-gray-400 md:grid-cols-2">
+          <p>
+            <span className="font-semibold text-gray-300">Iniciado em:</span> {formatarData(detalhe.iniciadoEm)}
+          </p>
+          <p>
+            <span className="font-semibold text-gray-300">Finalizado em:</span> {formatarData(detalhe.finalizadoEm)}
+          </p>
+        </div>
+      </Card>
+
+      <Card className="mb-6">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between py-3 text-left"
+          onClick={() => setErrosAbertos(prev => !prev)}
+        >
+          <div className="flex items-center gap-2 text-red-200">
+            <AlertTriangle size={18} />
+            <span className="font-semibold">Itens com erro</span>
+            <span className="rounded-full bg-red-500/20 px-2 py-0.5 text-xs text-red-200">
+              {itensErro.length}
+            </span>
+          </div>
+          {errosAbertos ? <ChevronUp size={18} className="text-gray-400" /> : <ChevronDown size={18} className="text-gray-400" />}
+        </button>
+        {errosAbertos && (
+          <div className="mt-4 space-y-4">
+            {itensErro.length === 0 ? (
+              <p className="text-sm text-gray-400">Nenhum registro com erro impeditivo.</p>
+            ) : (
+              itensErro.map(item => {
+                const mensagens = item.mensagens ?? {};
+                return (
+                  <div
+                    key={item.id}
+                    className="rounded-lg border border-red-500/40 bg-red-500/5 p-4 text-sm text-gray-200"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <p className="font-semibold text-white">Linha {item.linhaPlanilha}</p>
+                        <p className="text-xs text-gray-300">NCM {item.ncm || 'Não informada'}</p>
+                      </div>
+                    </div>
+                    <p className="mt-3 text-sm text-gray-200">
+                      Produto: <span className="font-medium text-white">{item.denominacao || 'Sem nome informado'}</span>
+                    </p>
+                    {item.codigosInternos && (
+                      <p className="mt-1 text-xs text-gray-300">SKUs informados: {item.codigosInternos}</p>
+                    )}
+                    <div className="mt-3">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-red-300">Problemas encontrados</p>
+                      {obterMensagem(mensagens.impeditivos) || (
+                        <p className="mt-2 text-sm text-gray-200">Erro não especificado.</p>
+                      )}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        )}
+      </Card>
+
+      <Card>
+        <button
+          type="button"
+          className="flex w-full items-center justify-between py-3 text-left"
+          onClick={() => setSucessosAbertos(prev => !prev)}
+        >
+          <div className="flex items-center gap-2 text-emerald-200">
+            <CheckCircle size={18} />
+            <span className="font-semibold">Itens importados com sucesso</span>
+            <span className="rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs text-emerald-200">
+              {itensSucesso.length}
+            </span>
+          </div>
+          {sucessosAbertos ? <ChevronUp size={18} className="text-gray-400" /> : <ChevronDown size={18} className="text-gray-400" />}
+        </button>
+        {sucessosAbertos && (
+          <div className="mt-4 space-y-4">
+            {itensSucesso.length === 0 ? (
+              <p className="text-sm text-gray-400">Nenhum item importado.</p>
+            ) : (
+              itensSucesso.map(item => {
+                const mensagens = item.mensagens ?? {};
+                const possuiAtencao = item.resultado === 'ATENCAO' || item.possuiAlerta;
+                return (
+                  <div
+                    key={item.id}
+                    className={`rounded-lg border p-4 text-sm ${
+                      possuiAtencao
+                        ? 'border-amber-500/40 bg-amber-500/10 text-amber-100'
+                        : 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100'
+                    }`}
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <p className="font-semibold text-white">Linha {item.linhaPlanilha}</p>
+                        <p className="text-xs text-white/80">NCM {item.ncm || 'Não informada'}</p>
+                      </div>
+                      {possuiAtencao && (
+                        <span className="rounded-full bg-amber-500/20 px-2 py-0.5 text-xs font-medium text-amber-100">
+                          Importado com atenção
+                        </span>
+                      )}
+                    </div>
+                    <p className="mt-2 text-sm text-white">
+                      Produto criado: <span className="font-semibold">{item.denominacao || 'Sem nome informado'}</span>
+                    </p>
+                    {item.codigosInternos && (
+                      <p className="mt-1 text-xs text-white/80">SKUs cadastrados: {item.codigosInternos}</p>
+                    )}
+                    {obterMensagem(mensagens.atencao)}
+                  </div>
+                );
+              })
+            )}
+          </div>
+        )}
+      </Card>
+    </DashboardLayout>
+  );
+}

--- a/frontend/pages/automacao/importar-produto/index.tsx
+++ b/frontend/pages/automacao/importar-produto/index.tsx
@@ -1,0 +1,242 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+import { Breadcrumb } from '@/components/ui/Breadcrumb';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { PageLoader } from '@/components/ui/PageLoader';
+import api from '@/lib/api';
+import { formatCPFOrCNPJ } from '@/lib/validation';
+import { useToast } from '@/components/ui/ToastContext';
+import { ArrowRight, PlusCircle, RefreshCcw } from 'lucide-react';
+
+interface ImportacaoResumo {
+  id: number;
+  catalogoId: number;
+  modalidade: string;
+  situacao: 'EM_ANDAMENTO' | 'CONCLUIDA';
+  resultado: 'PENDENTE' | 'SUCESSO' | 'ATENCAO';
+  totalRegistros: number;
+  totalCriados: number;
+  totalComAtencao: number;
+  totalComErro: number;
+  iniciadoEm: string;
+  finalizadoEm?: string | null;
+  nomeArquivo?: string | null;
+  catalogo: {
+    id: number;
+    nome: string;
+    numero: number;
+    cpf_cnpj?: string | null;
+  };
+}
+
+function useImportacoes() {
+  const [dados, setDados] = useState<ImportacaoResumo[]>([]);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState<string | null>(null);
+  const { addToast } = useToast();
+
+  const carregar = useCallback(async () => {
+    try {
+      setCarregando(true);
+      const resposta = await api.get<ImportacaoResumo[]>('/produtos/importacoes');
+      setDados(resposta.data);
+      setErro(null);
+    } catch (error) {
+      console.error('Erro ao carregar importações', error);
+      setErro('Não foi possível carregar as importações.');
+      addToast('Não foi possível carregar as importações.', 'error');
+    } finally {
+      setCarregando(false);
+    }
+  }, [addToast]);
+
+  useEffect(() => {
+    carregar();
+  }, [carregar]);
+
+  return { dados, carregando, erro, recarregar: carregar };
+}
+
+function obterClasseResultado(resultado: ImportacaoResumo['resultado']) {
+  switch (resultado) {
+    case 'SUCESSO':
+      return 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/40';
+    case 'ATENCAO':
+      return 'bg-amber-500/10 text-amber-400 border border-amber-500/40';
+    case 'PENDENTE':
+      return 'bg-slate-500/10 text-slate-300 border border-slate-500/40';
+    default:
+      return 'bg-slate-700/40 text-slate-200 border border-slate-600/40';
+  }
+}
+
+function obterClasseSituacao(situacao: ImportacaoResumo['situacao']) {
+  switch (situacao) {
+    case 'EM_ANDAMENTO':
+      return 'text-sky-400';
+    case 'CONCLUIDA':
+      return 'text-emerald-400';
+    default:
+      return 'text-slate-300';
+  }
+}
+
+function formatarData(data?: string | null) {
+  if (!data) return '-';
+  const objeto = new Date(data);
+  if (Number.isNaN(objeto.getTime())) return '-';
+  return `${objeto.toLocaleDateString('pt-BR')} ${objeto.toLocaleTimeString('pt-BR')}`;
+}
+
+function traduzResultado(resultado: ImportacaoResumo['resultado']) {
+  switch (resultado) {
+    case 'SUCESSO':
+      return 'Sucesso';
+    case 'ATENCAO':
+      return 'Atenção';
+    case 'PENDENTE':
+      return 'Pendente';
+  }
+}
+
+function traduzSituacao(situacao: ImportacaoResumo['situacao']) {
+  return situacao === 'CONCLUIDA' ? 'Concluída' : 'Em andamento';
+}
+
+function traduzModalidade(modalidade: string) {
+  if (modalidade === 'EXPORTACAO') return 'Exportação';
+  return 'Importação';
+}
+
+export default function ImportacoesPage() {
+  const router = useRouter();
+  const { dados, carregando, erro, recarregar } = useImportacoes();
+
+  if (carregando && dados.length === 0) {
+    return (
+      <DashboardLayout title="Importar Produto">
+        <PageLoader message="Carregando importações..." />
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout title="Importar Produto">
+      <Breadcrumb
+        items={[
+          { label: 'Automação' },
+          { label: 'Importar Produto' }
+        ]}
+      />
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">Importações de Produto</h1>
+          <p className="text-sm text-gray-400">Acompanhe o histórico de importações realizadas via planilha Excel.</p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={() => recarregar()}
+            title="Recarregar lista"
+            className="flex items-center gap-2"
+          >
+            <RefreshCcw size={16} />
+            Atualizar
+          </Button>
+          <Button
+            onClick={() => router.push('/automacao/importar-produto/nova')}
+            className="flex items-center gap-2"
+          >
+            <PlusCircle size={18} />
+            Nova Importação
+          </Button>
+        </div>
+      </div>
+
+      {erro && (
+        <Card className="mb-4 border border-red-500/40 bg-red-500/5 text-red-300">
+          <p>{erro}</p>
+        </Card>
+      )}
+
+      <Card>
+        {dados.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center text-gray-400">
+            <p className="text-lg font-medium">Nenhuma importação realizada até o momento.</p>
+            <p className="mt-2 text-sm">
+              Utilize o botão <strong>Nova Importação</strong> para iniciar o processo por planilha Excel.
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="bg-[#1f2430] text-xs uppercase text-gray-400">
+                <tr>
+                  <th className="px-4 py-3 text-left">Arquivo</th>
+                  <th className="px-4 py-3 text-left">Catálogo</th>
+                  <th className="px-4 py-3 text-left">Modalidade</th>
+                  <th className="px-4 py-3 text-left">Situação</th>
+                  <th className="px-4 py-3 text-left">Resultado</th>
+                  <th className="px-4 py-3 text-left">Registros</th>
+                  <th className="px-4 py-3 text-left">Criados</th>
+                  <th className="px-4 py-3 text-left">Com Atenção</th>
+                  <th className="px-4 py-3 text-left">Com Erro</th>
+                  <th className="px-4 py-3 text-left">Iniciado em</th>
+                  <th className="px-4 py-3 text-left">Concluído em</th>
+                  <th className="px-4 py-3 text-right">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {dados.map(importacao => (
+                  <tr key={importacao.id} className="border-b border-slate-800/60 hover:bg-slate-800/40">
+                    <td className="px-4 py-3 text-gray-200">
+                      {importacao.nomeArquivo || `Importação #${importacao.id}`}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-col text-gray-200">
+                        <span className="font-medium">{importacao.catalogo.nome}</span>
+                        <span className="text-xs text-gray-400">
+                          Nº {importacao.catalogo.numero} · {formatCPFOrCNPJ(importacao.catalogo.cpf_cnpj || '')}
+                        </span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-gray-200">{traduzModalidade(importacao.modalidade)}</td>
+                    <td className={`px-4 py-3 font-medium ${obterClasseSituacao(importacao.situacao)}`}>
+                      {traduzSituacao(importacao.situacao)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${obterClasseResultado(importacao.resultado)}`}>
+                        {traduzResultado(importacao.resultado)}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-200">{importacao.totalRegistros}</td>
+                    <td className="px-4 py-3 text-gray-200">{importacao.totalCriados}</td>
+                    <td className="px-4 py-3 text-amber-300">{importacao.totalComAtencao}</td>
+                    <td className="px-4 py-3 text-red-300">{importacao.totalComErro}</td>
+                    <td className="px-4 py-3 text-gray-200">{formatarData(importacao.iniciadoEm)}</td>
+                    <td className="px-4 py-3 text-gray-200">{formatarData(importacao.finalizadoEm)}</td>
+                    <td className="px-4 py-3 text-right">
+                      <Button
+                        variant="outline"
+                        className="text-sm text-blue-300 hover:text-white"
+                        onClick={() => router.push(`/automacao/importar-produto/${importacao.id}`)}
+                      >
+                        <span className="inline-flex items-center gap-2">
+                          Detalhes
+                          <ArrowRight size={16} />
+                        </span>
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </DashboardLayout>
+  );
+}

--- a/frontend/pages/automacao/importar-produto/nova.tsx
+++ b/frontend/pages/automacao/importar-produto/nova.tsx
@@ -1,0 +1,298 @@
+import React, { ChangeEvent, FormEvent, useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+import { Breadcrumb } from '@/components/ui/Breadcrumb';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Select } from '@/components/ui/Select';
+import { useToast } from '@/components/ui/ToastContext';
+import api from '@/lib/api';
+import { useWorkingCatalog } from '@/contexts/WorkingCatalogContext';
+import { formatCPFOrCNPJ } from '@/lib/validation';
+import { FileSpreadsheet, Info, Layers } from 'lucide-react';
+
+interface CatalogoResumo {
+  id: number;
+  nome: string;
+  numero: number;
+  cpf_cnpj?: string | null;
+}
+
+type ModalidadeImportacao = 'PLANILHA' | 'SISCOMEX';
+
+type ModalidadeProduto = 'IMPORTACAO' | 'EXPORTACAO';
+
+interface ArquivoSelecionado {
+  nome: string;
+  conteudoBase64: string;
+}
+
+export default function NovaImportacaoPage() {
+  const router = useRouter();
+  const { addToast } = useToast();
+  const { workingCatalog } = useWorkingCatalog();
+
+  const [catalogos, setCatalogos] = useState<CatalogoResumo[]>([]);
+  const [catalogoId, setCatalogoId] = useState('');
+  const [modalidadeImportacao, setModalidadeImportacao] = useState<ModalidadeImportacao>('PLANILHA');
+  const [modalidadeProduto, setModalidadeProduto] = useState<ModalidadeProduto>('IMPORTACAO');
+  const [arquivo, setArquivo] = useState<ArquivoSelecionado | null>(null);
+  const [arquivoNome, setArquivoNome] = useState('');
+  const [carregandoArquivo, setCarregandoArquivo] = useState(false);
+  const [submetendo, setSubmetendo] = useState(false);
+  const [erros, setErros] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    const carregarCatalogos = async () => {
+      try {
+        const resposta = await api.get<CatalogoResumo[]>('/catalogos');
+        setCatalogos(resposta.data);
+      } catch (error) {
+        console.error('Erro ao carregar catálogos', error);
+        addToast('Não foi possível carregar os catálogos.', 'error');
+      }
+    };
+    carregarCatalogos();
+  }, [addToast]);
+
+  useEffect(() => {
+    if (workingCatalog) {
+      setCatalogoId(String(workingCatalog.id));
+    }
+  }, [workingCatalog]);
+
+  const limparArquivo = () => {
+    setArquivo(null);
+    setArquivoNome('');
+  };
+
+  const lerArquivoComoBase64 = useCallback((file: File) => {
+    return new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const resultado = reader.result as string;
+        const base64 = resultado.includes(',') ? resultado.split(',')[1] : resultado;
+        resolve(base64);
+      };
+      reader.onerror = () => reject(reader.error || new Error('Falha ao ler o arquivo'));
+      reader.readAsDataURL(file);
+    });
+  }, []);
+
+  const handleArquivoChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    setErros(prev => ({ ...prev, arquivo: '' }));
+
+    if (!file) {
+      limparArquivo();
+      return;
+    }
+
+    if (!file.name.toLowerCase().endsWith('.xlsx')) {
+      limparArquivo();
+      setErros(prev => ({ ...prev, arquivo: 'Envie um arquivo no formato .xlsx' }));
+      return;
+    }
+
+    try {
+      setCarregandoArquivo(true);
+      const conteudo = await lerArquivoComoBase64(file);
+      setArquivo({ nome: file.name, conteudoBase64: conteudo });
+      setArquivoNome(file.name);
+    } catch (error) {
+      console.error('Erro ao carregar arquivo', error);
+      limparArquivo();
+      setErros(prev => ({ ...prev, arquivo: 'Não foi possível processar o arquivo selecionado.' }));
+    } finally {
+      setCarregandoArquivo(false);
+    }
+  };
+
+  const validarFormulario = () => {
+    const novosErros: Record<string, string> = {};
+    if (!catalogoId) {
+      novosErros.catalogoId = 'Selecione um catálogo para realizar a importação';
+    }
+    if (!arquivo) {
+      novosErros.arquivo = 'Envie um arquivo Excel (.xlsx) com os produtos';
+    }
+    setErros(novosErros);
+    return Object.keys(novosErros).length === 0;
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (modalidadeImportacao !== 'PLANILHA') return;
+
+    if (!validarFormulario()) {
+      return;
+    }
+
+    try {
+      setSubmetendo(true);
+      const resposta = await api.post('/produtos/importacao', {
+        catalogoId: Number(catalogoId),
+        modalidade: modalidadeProduto,
+        arquivo: arquivo,
+      });
+
+      addToast('Importação concluída!', 'success');
+      router.push(`/automacao/importar-produto/${resposta.data.id}`);
+    } catch (error: any) {
+      console.error('Erro ao iniciar importação', error);
+      const mensagem = error.response?.data?.error || 'Falha ao iniciar a importação.';
+      addToast(mensagem, 'error');
+    } finally {
+      setSubmetendo(false);
+    }
+  };
+
+  return (
+    <DashboardLayout title="Nova Importação de Produtos">
+      <Breadcrumb
+        items={[
+          { label: 'Automação', href: '/automacao/importar-produto' },
+          { label: 'Importar Produto', href: '/automacao/importar-produto' },
+          { label: 'Nova Importação' }
+        ]}
+      />
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-white">Nova Importação de Produtos</h1>
+        <p className="mt-2 text-sm text-gray-400">
+          Escolha a modalidade desejada e informe os dados necessários para iniciar a importação do catálogo.
+        </p>
+      </div>
+
+      <div className="mb-4 grid gap-3 sm:grid-cols-2">
+        <button
+          type="button"
+          onClick={() => setModalidadeImportacao('PLANILHA')}
+          className={`flex items-center gap-3 rounded-lg border px-4 py-3 text-left transition ${
+            modalidadeImportacao === 'PLANILHA'
+              ? 'border-emerald-500 bg-emerald-500/10 text-emerald-100'
+              : 'border-slate-700 bg-slate-800/40 text-gray-300 hover:border-emerald-500/40'
+          }`}
+        >
+          <FileSpreadsheet size={24} />
+          <div>
+            <p className="text-sm font-semibold">Planilha Excel</p>
+            <p className="text-xs text-gray-400">Importe produtos a partir de um arquivo .xlsx seguindo o layout padrão.</p>
+          </div>
+        </button>
+        <button
+          type="button"
+          onClick={() => setModalidadeImportacao('SISCOMEX')}
+          className={`flex items-center gap-3 rounded-lg border px-4 py-3 text-left transition ${
+            modalidadeImportacao === 'SISCOMEX'
+              ? 'border-slate-500 bg-slate-500/20 text-slate-100'
+              : 'border-slate-700 bg-slate-800/40 text-gray-300 hover:border-slate-500/40'
+          }`}
+        >
+          <Layers size={24} />
+          <div>
+            <p className="text-sm font-semibold">Importar do Siscomex</p>
+            <p className="text-xs text-gray-400">Sincronize produtos diretamente do Siscomex (em desenvolvimento).</p>
+          </div>
+        </button>
+      </div>
+
+      {modalidadeImportacao === 'SISCOMEX' ? (
+        <Card className="border border-amber-500/40 bg-amber-500/10">
+          <div className="flex items-center gap-3">
+            <Info size={24} className="text-amber-300" />
+            <div>
+              <h2 className="text-lg font-semibold text-amber-100">Funcionalidade em desenvolvimento</h2>
+              <p className="mt-1 text-sm text-amber-100/80">
+                A importação direta do Siscomex ainda está sendo construída. Utilize a opção de Planilha Excel para importar produtos.
+              </p>
+            </div>
+          </div>
+        </Card>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <Card>
+            <div className="grid gap-4 md:grid-cols-2">
+              {workingCatalog ? (
+                <Input
+                  label="Catálogo"
+                  value={`${workingCatalog.nome} · Nº ${workingCatalog.numero} · ${formatCPFOrCNPJ(workingCatalog.cpf_cnpj || '')}`}
+                  disabled
+                />
+              ) : (
+                <Select
+                  label="Catálogo"
+                  value={catalogoId}
+                  onChange={event => setCatalogoId(event.target.value)}
+                  options={catalogos.map(c => ({
+                    value: String(c.id),
+                    label: `${c.nome} · Nº ${c.numero} · ${formatCPFOrCNPJ(c.cpf_cnpj || '')}`
+                  }))}
+                  error={erros.catalogoId}
+                  required
+                />
+              )}
+
+              <Select
+                label="Modalidade do produto"
+                value={modalidadeProduto}
+                onChange={event => setModalidadeProduto(event.target.value as ModalidadeProduto)}
+                options={[
+                  { value: 'IMPORTACAO', label: 'Importação' },
+                  { value: 'EXPORTACAO', label: 'Exportação' }
+                ]}
+              />
+            </div>
+
+            <div className="mt-4">
+              <Input
+                type="file"
+                label="Planilha Excel (.xlsx)"
+                accept=".xlsx"
+                onChange={handleArquivoChange}
+                error={erros.arquivo}
+              />
+              {arquivoNome && (
+                <p className="mt-1 text-sm text-gray-300">
+                  Arquivo selecionado: <span className="font-medium text-white">{arquivoNome}</span>
+                  {carregandoArquivo && <span className="ml-2 text-xs text-gray-400">Convertendo arquivo...</span>}
+                </p>
+              )}
+            </div>
+          </Card>
+
+          <Card className="border border-slate-700 bg-slate-800/40">
+            <h2 className="text-lg font-semibold text-white">Instruções do arquivo</h2>
+            <p className="mt-2 text-sm text-gray-300">
+              A planilha deve conter os seguintes campos na primeira linha (cabeçalho):
+            </p>
+            <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-gray-300">
+              <li><strong>Coluna A – NCM:</strong> código numérico de 8 dígitos, sem formatação.</li>
+              <li><strong>Coluna B – Denominação:</strong> nome do produto. Será replicado no campo descrição.</li>
+              <li><strong>Coluna C – Código interno / Partnumber:</strong> SKUs separados por vírgula (somente números).</li>
+            </ul>
+            <p className="mt-3 text-xs text-gray-400">
+              Dicas: deixe linhas vazias no final da planilha em branco, garanta que a primeira linha contenha o cabeçalho indicado e salve o arquivo no formato .xlsx.
+            </p>
+          </Card>
+
+          <div className="flex justify-end gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => router.push('/automacao/importar-produto')}
+              className="text-gray-300 hover:text-white"
+              disabled={submetendo}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={submetendo || carregandoArquivo}>
+              {submetendo ? 'Importando...' : 'Iniciar importação'}
+            </Button>
+          </div>
+        </form>
+      )}
+    </DashboardLayout>
+  );
+}

--- a/scripts_banco_catalogo_produtos.sql
+++ b/scripts_banco_catalogo_produtos.sql
@@ -326,6 +326,49 @@ DELIMITER ;
         FOREIGN KEY (produto_id) REFERENCES produto(id) ON DELETE CASCADE
     );
 
+    CREATE TABLE IF NOT EXISTS importacao_produto (
+        id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+        super_user_id INT UNSIGNED NOT NULL,
+        usuario_catalogo_id INT UNSIGNED NULL,
+        catalogo_id INT UNSIGNED NOT NULL,
+        modalidade VARCHAR(50) NOT NULL,
+        nome_arquivo VARCHAR(255),
+        situacao ENUM('EM_ANDAMENTO', 'CONCLUIDA') NOT NULL DEFAULT 'EM_ANDAMENTO',
+        resultado ENUM('PENDENTE', 'SUCESSO', 'ATENCAO') NOT NULL DEFAULT 'PENDENTE',
+        total_registros INT UNSIGNED NOT NULL DEFAULT 0,
+        total_criados INT UNSIGNED NOT NULL DEFAULT 0,
+        total_com_atencao INT UNSIGNED NOT NULL DEFAULT 0,
+        total_com_erro INT UNSIGNED NOT NULL DEFAULT 0,
+        iniciado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        finalizado_em DATETIME NULL,
+        PRIMARY KEY (id),
+        INDEX idx_importacao_super_user (super_user_id),
+        INDEX idx_importacao_catalogo (catalogo_id),
+        -- Integridade com o superusuário garantida via aplicação, conforme catálogo
+        CONSTRAINT fk_importacao_produto_catalogo FOREIGN KEY (catalogo_id) REFERENCES catalogo(id),
+        CONSTRAINT fk_importacao_produto_usuario FOREIGN KEY (usuario_catalogo_id) REFERENCES usuario_catalogo(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS importacao_produto_item (
+        id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+        importacao_id INT UNSIGNED NOT NULL,
+        linha_planilha INT NOT NULL,
+        ncm VARCHAR(8),
+        denominacao VARCHAR(255),
+        codigos_internos TEXT,
+        resultado ENUM('SUCESSO', 'ATENCAO', 'ERRO') NOT NULL,
+        mensagens JSON NULL,
+        possui_erro_impeditivo TINYINT(1) NOT NULL DEFAULT 0,
+        possui_alerta TINYINT(1) NOT NULL DEFAULT 0,
+        produto_id INT UNSIGNED NULL,
+        criado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (id),
+        INDEX idx_importacao_item_importacao (importacao_id),
+        INDEX idx_importacao_item_resultado (resultado),
+        CONSTRAINT fk_importacao_produto_item_importacao FOREIGN KEY (importacao_id) REFERENCES importacao_produto(id) ON DELETE CASCADE,
+        CONSTRAINT fk_importacao_produto_item_produto FOREIGN KEY (produto_id) REFERENCES produto(id)
+    );
+
 
     -- Scripts de dados iniciais para Operador Estrangeiro
     -- Execute após criar as tabelas


### PR DESCRIPTION
## Resumo
- remove a migração do Prisma e documenta as tabelas de importação no DDL consolidado e em script incremental
- ajusta o schema do Prisma para relacionar as importações ao superusuário e ao usuário do catálogo responsável
- atualiza o serviço para buscar o usuário do catálogo pelo legacyId antes de registrar a importação
- elimina a constraint de FK para superusuário nas tabelas de importação, seguindo o padrão do catálogo

## Testes
- npm run build (backend)
- CI=1 npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68dc39b404088330aab50a57b027aae2