### PR TITLE
Ajusta UX das importações e permite limpar histórico

### DIFF
--- a/backend/src/controllers/produto-importacao.controller.ts
+++ b/backend/src/controllers/produto-importacao.controller.ts
@@ -88,3 +88,36 @@ export async function obterDetalhesImportacao(req: Request, res: Response) {
     return res.status(500).json({ error: 'Erro ao obter detalhes da importação' });
   }
 }
+
+export async function removerImportacao(req: Request, res: Response) {
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) {
+      return res.status(400).json({ error: 'Identificador inválido' });
+    }
+
+    const removida = await produtoImportacaoService.removerImportacao(
+      id,
+      req.user!.superUserId
+    );
+
+    if (!removida) {
+      return res.status(404).json({ error: 'Importação não encontrada' });
+    }
+
+    return res.status(204).send();
+  } catch (error) {
+    logger.error('Erro ao remover importação:', error);
+    return res.status(500).json({ error: 'Erro ao remover importação' });
+  }
+}
+
+export async function limparImportacoes(req: Request, res: Response) {
+  try {
+    await produtoImportacaoService.limparHistorico(req.user!.superUserId);
+    return res.status(204).send();
+  } catch (error) {
+    logger.error('Erro ao limpar histórico de importação:', error);
+    return res.status(500).json({ error: 'Erro ao limpar histórico de importação' });
+  }
+}

--- a/backend/src/routes/produto.routes.ts
+++ b/backend/src/routes/produto.routes.ts
@@ -11,7 +11,9 @@ import {
 import {
   importarProdutosPorPlanilha,
   listarImportacoes,
-  obterDetalhesImportacao
+  obterDetalhesImportacao,
+  removerImportacao,
+  limparImportacoes
 } from '../controllers/produto-importacao.controller';
 import { authMiddleware } from '../middlewares/auth.middleware';
 import { validate } from '../middlewares/validate.middleware';
@@ -28,6 +30,8 @@ router.use(authMiddleware);
 router.get('/importacoes', listarImportacoes);
 router.get('/importacoes/:id', obterDetalhesImportacao);
 router.post('/importacao', importarProdutosPorPlanilha);
+router.delete('/importacoes/:id', removerImportacao);
+router.delete('/importacoes', limparImportacoes);
 
 router.get('/', listarProdutos);
 router.get('/:id', obterProduto);

--- a/backend/src/services/produto-importacao.service.ts
+++ b/backend/src/services/produto-importacao.service.ts
@@ -277,6 +277,26 @@ export class ProdutoImportacaoService {
     });
   }
 
+  async removerImportacao(id: number, superUserId: number) {
+    const existente = await catalogoPrisma.importacaoProduto.findFirst({
+      where: { id, superUserId },
+      select: { id: true }
+    });
+
+    if (!existente) {
+      return false;
+    }
+
+    await catalogoPrisma.importacaoProduto.delete({ where: { id: existente.id } });
+    return true;
+  }
+
+  async limparHistorico(superUserId: number) {
+    await catalogoPrisma.importacaoProduto.deleteMany({
+      where: { superUserId }
+    });
+  }
+
   private converterBase64(base64: string): Buffer {
     const limpo = base64.replace(/^data:[^;]+;base64,/, '').trim();
     return Buffer.from(limpo, 'base64');

--- a/frontend/pages/automacao/importar-produto/[id].tsx
+++ b/frontend/pages/automacao/importar-produto/[id].tsx
@@ -151,7 +151,8 @@ export default function ImportacaoDetalhePage() {
       <DashboardLayout title="Detalhes da Importação">
         <Breadcrumb
           items={[
-            { label: 'Automação', href: '/automacao/importar-produto' },
+            { label: 'Início', href: '/' },
+            { label: 'Automação' },
             { label: 'Importar Produto', href: '/automacao/importar-produto' },
             { label: 'Detalhes' }
           ]}
@@ -172,69 +173,75 @@ export default function ImportacaoDetalhePage() {
     <DashboardLayout title="Detalhes da Importação">
       <Breadcrumb
         items={[
-          { label: 'Automação', href: '/automacao/importar-produto' },
+          { label: 'Início', href: '/' },
+          { label: 'Automação' },
           { label: 'Importar Produto', href: '/automacao/importar-produto' },
           { label: `Importação #${detalhe.id}` }
         ]}
       />
 
-      <div className="mb-4 flex flex-wrap items-center gap-3">
-        <Button
-          variant="outline"
-          className="flex items-center gap-2 text-gray-300 hover:text-white"
-          onClick={() => router.push('/automacao/importar-produto')}
-        >
-          <ArrowLeft size={16} />
-          Voltar para importações
-        </Button>
+      <div className="mb-6 flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => router.push('/automacao/importar-produto')}
+            className="text-gray-400 transition-colors hover:text-white"
+            aria-label="Voltar para a listagem de importações"
+          >
+            <ArrowLeft size={20} />
+          </button>
+          <h1 className="text-2xl font-semibold text-white">Importação #{detalhe.id}</h1>
+        </div>
+        <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-sm font-medium ${obterClasseResultado(detalhe.resultado)}`}>
+          Resultado: {traduzResultado(detalhe.resultado)}
+        </span>
       </div>
 
       <Card className="mb-6">
-        <div className="grid gap-4 lg:grid-cols-2">
-          <div>
-            <h1 className="text-2xl font-semibold text-white">Importação #{detalhe.id}</h1>
-            <p className="mt-1 text-sm text-gray-400">
-              {detalhe.nomeArquivo ? `Arquivo ${detalhe.nomeArquivo}` : 'Arquivo não informado'}
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2 text-sm text-gray-300">
+            <p className="text-gray-300">
+              <span className="font-semibold text-gray-200">Arquivo:</span>{' '}
+              {detalhe.nomeArquivo ? detalhe.nomeArquivo : 'Não informado'}
             </p>
-            <p className="mt-1 text-sm text-gray-400">
-              Catálogo {detalhe.catalogo.nome} · Nº {detalhe.catalogo.numero} ·{' '}
+            <p className="text-gray-300">
+              <span className="font-semibold text-gray-200">Catálogo:</span>{' '}
+              {detalhe.catalogo.nome} · Nº {detalhe.catalogo.numero} ·{' '}
               {formatCPFOrCNPJ(detalhe.catalogo.cpf_cnpj || '')}
             </p>
-            <p className="mt-2 text-sm text-gray-400">
-              Modalidade {traduzModalidade(detalhe.modalidade)} · Situação {traduzSituacao(detalhe.situacao)}
+            <p className="text-gray-300">
+              <span className="font-semibold text-gray-200">Modalidade:</span> {traduzModalidade(detalhe.modalidade)}
             </p>
-            <div className="mt-3">
-              <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-sm font-medium ${obterClasseResultado(detalhe.resultado)}`}>
-                Resultado: {traduzResultado(detalhe.resultado)}
-              </span>
+            <p className="text-gray-300">
+              <span className="font-semibold text-gray-200">Situação:</span> {traduzSituacao(detalhe.situacao)}
+            </p>
+            <div className="flex flex-wrap gap-6 text-sm text-gray-400">
+              <p>
+                <span className="font-semibold text-gray-300">Iniciado em:</span> {formatarData(detalhe.iniciadoEm)}
+              </p>
+              <p>
+                <span className="font-semibold text-gray-300">Finalizado em:</span> {formatarData(detalhe.finalizadoEm)}
+              </p>
             </div>
           </div>
-          <div className="grid grid-cols-2 gap-3 text-center text-sm text-gray-300">
-            <div className="rounded-lg border border-slate-700 bg-slate-800/40 p-4">
+          <div className="flex flex-wrap gap-3 text-sm">
+            <div className="min-w-[150px] rounded-lg border border-slate-700 bg-slate-800/40 p-3 text-gray-300">
               <p className="text-xs uppercase tracking-wide text-gray-400">Registros analisados</p>
-              <p className="mt-1 text-2xl font-semibold text-white">{detalhe.totalRegistros}</p>
+              <p className="mt-1 text-xl font-semibold text-white">{detalhe.totalRegistros}</p>
             </div>
-            <div className="rounded-lg border border-emerald-600/40 bg-emerald-600/10 p-4">
-              <p className="text-xs uppercase tracking-wide text-emerald-300">Produtos criados</p>
-              <p className="mt-1 text-2xl font-semibold text-emerald-200">{detalhe.totalCriados}</p>
+            <div className="min-w-[150px] rounded-lg border border-emerald-600/40 bg-emerald-600/10 p-3 text-emerald-100">
+              <p className="text-xs uppercase tracking-wide text-emerald-200">Produtos criados</p>
+              <p className="mt-1 text-xl font-semibold text-emerald-50">{detalhe.totalCriados}</p>
             </div>
-            <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-4">
-              <p className="text-xs uppercase tracking-wide text-amber-300">Com atenção</p>
-              <p className="mt-1 text-2xl font-semibold text-amber-200">{detalhe.totalComAtencao}</p>
+            <div className="min-w-[150px] rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-amber-100">
+              <p className="text-xs uppercase tracking-wide text-amber-200">Com atenção</p>
+              <p className="mt-1 text-xl font-semibold text-amber-50">{detalhe.totalComAtencao}</p>
             </div>
-            <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-4">
-              <p className="text-xs uppercase tracking-wide text-red-300">Com erro</p>
-              <p className="mt-1 text-2xl font-semibold text-red-200">{detalhe.totalComErro}</p>
+            <div className="min-w-[150px] rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-red-100">
+              <p className="text-xs uppercase tracking-wide text-red-200">Com erro</p>
+              <p className="mt-1 text-xl font-semibold text-red-50">{detalhe.totalComErro}</p>
             </div>
           </div>
-        </div>
-        <div className="mt-4 grid gap-3 text-sm text-gray-400 md:grid-cols-2">
-          <p>
-            <span className="font-semibold text-gray-300">Iniciado em:</span> {formatarData(detalhe.iniciadoEm)}
-          </p>
-          <p>
-            <span className="font-semibold text-gray-300">Finalizado em:</span> {formatarData(detalhe.finalizadoEm)}
-          </p>
         </div>
       </Card>
 

--- a/frontend/pages/automacao/importar-produto/nova.tsx
+++ b/frontend/pages/automacao/importar-produto/nova.tsx
@@ -152,7 +152,8 @@ export default function NovaImportacaoPage() {
     <DashboardLayout title="Nova Importação de Produtos">
       <Breadcrumb
         items={[
-          { label: 'Automação', href: '/automacao/importar-produto' },
+          { label: 'Início', href: '/' },
+          { label: 'Automação' },
           { label: 'Importar Produto', href: '/automacao/importar-produto' },
           { label: 'Nova Importação' }
         ]}
@@ -160,9 +161,6 @@ export default function NovaImportacaoPage() {
 
       <div className="mb-6">
         <h1 className="text-2xl font-semibold text-white">Nova Importação de Produtos</h1>
-        <p className="mt-2 text-sm text-gray-400">
-          Escolha a modalidade desejada e informe os dados necessários para iniciar a importação do catálogo.
-        </p>
       </div>
 
       <div className="mb-4 grid gap-3 sm:grid-cols-2">


### PR DESCRIPTION
## Resumo
- adiciona endpoints para excluir uma importação específica e limpar o histórico completo
- reorganiza as páginas de importação com breadcrumb iniciando em Início e ações em ícones com tooltip nativo
- compacta o cabeçalho da tela de detalhes e move o chip de resultado para ao lado do título

## Testes
- npm run build:all

------
https://chatgpt.com/codex/tasks/task_e_68dd7b921c688330a14449ccad3b6f56