### PR TITLE
Padroniza botões de novo e ações superiores em formulários

### DIFF
--- a/frontend/pages/automacao/importar-produto/index.tsx
+++ b/frontend/pages/automacao/importar-produto/index.tsx
@@ -200,6 +200,7 @@ export default function ImportacoesPage() {
           <Button
             onClick={() => router.push('/automacao/importar-produto/nova')}
             className="flex items-center gap-2"
+            variant="accent"
           >
             <PlusCircle size={18} />
             Nova Importação

--- a/frontend/pages/automacao/importar-produto/nova.tsx
+++ b/frontend/pages/automacao/importar-produto/nova.tsx
@@ -10,7 +10,7 @@ import { useToast } from '@/components/ui/ToastContext';
 import api from '@/lib/api';
 import { useWorkingCatalog } from '@/contexts/WorkingCatalogContext';
 import { formatCPFOrCNPJ } from '@/lib/validation';
-import { FileSpreadsheet, Info, Layers } from 'lucide-react';
+import { FileSpreadsheet, Info, Layers, Save } from 'lucide-react';
 
 interface CatalogoResumo {
   id: number;
@@ -42,6 +42,9 @@ export default function NovaImportacaoPage() {
   const [carregandoArquivo, setCarregandoArquivo] = useState(false);
   const [submetendo, setSubmetendo] = useState(false);
   const [erros, setErros] = useState<Record<string, string>>({});
+  const isPlanilha = modalidadeImportacao === 'PLANILHA';
+  const formId = 'nova-importacao-form';
+  const submitLabel = submetendo ? 'Importando...' : 'Iniciar importação';
 
   useEffect(() => {
     const carregarCatalogos = async () => {
@@ -159,8 +162,30 @@ export default function NovaImportacaoPage() {
         ]}
       />
 
-      <div className="mb-6">
+      <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <h1 className="text-2xl font-semibold text-white">Nova Importação de Produtos</h1>
+        <div className="flex items-center gap-3 self-end md:self-auto">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.push('/automacao/importar-produto')}
+            disabled={submetendo || carregandoArquivo}
+          >
+            Cancelar
+          </Button>
+          {isPlanilha && (
+            <Button
+              type="submit"
+              form={formId}
+              variant="accent"
+              className="flex items-center gap-2"
+              disabled={submetendo || carregandoArquivo}
+            >
+              <Save size={16} />
+              {submitLabel}
+            </Button>
+          )}
+        </div>
       </div>
 
       <div className="mb-4 grid gap-3 sm:grid-cols-2">
@@ -196,20 +221,8 @@ export default function NovaImportacaoPage() {
         </button>
       </div>
 
-      {modalidadeImportacao === 'SISCOMEX' ? (
-        <Card className="border border-amber-500/40 bg-amber-500/10">
-          <div className="flex items-center gap-3">
-            <Info size={24} className="text-amber-300" />
-            <div>
-              <h2 className="text-lg font-semibold text-amber-100">Funcionalidade em desenvolvimento</h2>
-              <p className="mt-1 text-sm text-amber-100/80">
-                A importação direta do Siscomex ainda está sendo construída. Utilize a opção de Planilha Excel para importar produtos.
-              </p>
-            </div>
-          </div>
-        </Card>
-      ) : (
-        <form onSubmit={handleSubmit} className="space-y-6">
+      {isPlanilha ? (
+        <form id={formId} onSubmit={handleSubmit} className="space-y-6">
           <Card>
             <div className="grid gap-4 md:grid-cols-2">
               {workingCatalog ? (
@@ -281,15 +294,33 @@ export default function NovaImportacaoPage() {
               variant="outline"
               onClick={() => router.push('/automacao/importar-produto')}
               className="text-gray-300 hover:text-white"
-              disabled={submetendo}
+              disabled={submetendo || carregandoArquivo}
             >
               Cancelar
             </Button>
-            <Button type="submit" disabled={submetendo || carregandoArquivo}>
-              {submetendo ? 'Importando...' : 'Iniciar importação'}
+            <Button
+              type="submit"
+              disabled={submetendo || carregandoArquivo}
+              variant="accent"
+              className="flex items-center gap-2"
+            >
+              <Save size={16} />
+              {submitLabel}
             </Button>
           </div>
         </form>
+      ) : (
+        <Card className="border border-amber-500/40 bg-amber-500/10">
+          <div className="flex items-center gap-3">
+            <Info size={24} className="text-amber-300" />
+            <div>
+              <h2 className="text-lg font-semibold text-amber-100">Funcionalidade em desenvolvimento</h2>
+              <p className="mt-1 text-sm text-amber-100/80">
+                A importação direta do Siscomex ainda está sendo construída. Utilize a opção de Planilha Excel para importar produtos.
+              </p>
+            </div>
+          </div>
+        </Card>
       )}
     </DashboardLayout>
   );

--- a/frontend/pages/catalogos/[id].tsx
+++ b/frontend/pages/catalogos/[id].tsx
@@ -57,6 +57,8 @@ export default function CatalogoFormPage() {
   const isNew = !id || id === 'novo';
   const { addToast } = useToast();
   const { workingCatalog, setWorkingCatalog } = useWorkingCatalog();
+  const formId = 'catalogo-form';
+  const salvarLabel = submitting ? 'Salvando...' : 'Salvar Catálogo';
 
   useEffect(() => {
     carregarCertificados();
@@ -236,7 +238,7 @@ export default function CatalogoFormPage() {
 
   const dadosContent = (
     <Card>
-      <form onSubmit={handleSubmit}>
+      <form id={formId} onSubmit={handleSubmit}>
         <div className="grid grid-cols-2 gap-4">
           {!isNew && catalogo && (
             <>
@@ -310,12 +312,12 @@ export default function CatalogoFormPage() {
         </div>
 
         <div className="mt-6 flex justify-end gap-3">
-          <Button type="button" variant="outline" onClick={voltar}>
+          <Button type="button" variant="outline" onClick={voltar} disabled={submitting}>
             Cancelar
           </Button>
           <Button type="submit" variant="accent" className="flex items-center gap-2" disabled={submitting}>
             <Save size={16} />
-            {submitting ? 'Salvando...' : 'Salvar Catálogo'}
+            {salvarLabel}
           </Button>
         </div>
       </form>
@@ -359,16 +361,38 @@ export default function CatalogoFormPage() {
           ]}
         />
 
-        <div className="mb-6 flex items-center gap-2">
-          <button
-            onClick={voltar}
-            className="text-gray-400 hover:text-white transition-colors"
-          >
-            <ArrowLeft size={20} />
-          </button>
-          <h1 className="text-2xl font-semibold text-white">
-            {isNew ? 'Criar Novo Catálogo' : 'Editar Catálogo'}
-          </h1>
+        <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={voltar}
+              className="text-gray-400 hover:text-white transition-colors"
+            >
+              <ArrowLeft size={20} />
+            </button>
+            <h1 className="text-2xl font-semibold text-white">
+              {isNew ? 'Criar Novo Catálogo' : 'Editar Catálogo'}
+            </h1>
+          </div>
+          <div className="flex items-center gap-3 self-end md:self-auto">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={voltar}
+              disabled={submitting}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              form={formId}
+              variant="accent"
+              className="flex items-center gap-2"
+              disabled={submitting}
+            >
+              <Save size={16} />
+              {salvarLabel}
+            </Button>
+          </div>
         </div>
         {dadosContent}
         {!isNew && certificadoContent}

--- a/frontend/pages/certificados/novo.tsx
+++ b/frontend/pages/certificados/novo.tsx
@@ -8,6 +8,7 @@ import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { useToast } from '@/components/ui/ToastContext';
 import api from '@/lib/api';
 import { useRouter } from 'next/router';
+import { Save } from 'lucide-react';
 
 export default function NovoCertificadoPage() {
   const [file, setFile] = useState<File | null>(null);
@@ -16,6 +17,8 @@ export default function NovoCertificadoPage() {
   const [enviando, setEnviando] = useState(false);
   const { addToast } = useToast();
   const router = useRouter();
+  const podeEnviar = Boolean(file && password && nome);
+  const submitLabel = enviando ? 'Enviando...' : 'Enviar';
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0];
@@ -73,8 +76,22 @@ export default function NovoCertificadoPage() {
         ]}
       />
 
-      <div className="mb-6">
+      <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <h1 className="text-2xl font-semibold text-white">Cadastrar Certificado</h1>
+        <div className="flex items-center gap-3 self-end md:self-auto">
+          <Button variant="outline" onClick={() => router.push('/certificados')} disabled={enviando}>
+            Cancelar
+          </Button>
+          <Button
+            variant="accent"
+            className="flex items-center gap-2"
+            onClick={upload}
+            disabled={!podeEnviar || enviando}
+          >
+            <Save size={16} />
+            {submitLabel}
+          </Button>
+        </div>
       </div>
 
       <Card>
@@ -83,9 +100,17 @@ export default function NovoCertificadoPage() {
           <FileInput label="Certificado (.pfx)" accept=".pfx" onChange={handleFileChange} />
           <Input label="Senha" type="password" value={password} onChange={e => setPassword(e.target.value)} />
           <div className="flex gap-3 justify-end pt-2">
-            <Button variant="outline" onClick={() => router.push('/certificados')}>Cancelar</Button>
-            <Button onClick={upload} disabled={!file || !password || !nome || enviando}>
-              {enviando ? 'Enviando...' : 'Enviar'}
+            <Button variant="outline" onClick={() => router.push('/certificados')} disabled={enviando}>
+              Cancelar
+            </Button>
+            <Button
+              onClick={upload}
+              disabled={!podeEnviar || enviando}
+              variant="accent"
+              className="flex items-center gap-2"
+            >
+              <Save size={16} />
+              {submitLabel}
             </Button>
           </div>
         </div>

--- a/frontend/pages/operadores-estrangeiros/[id].tsx
+++ b/frontend/pages/operadores-estrangeiros/[id].tsx
@@ -147,6 +147,8 @@ export default function OperadorEstrangeiroFormPage() {
   const isNew = !id || id === 'novo';
   const { addToast } = useToast();
   const { workingCatalog } = useWorkingCatalog();
+  const formId = 'operador-estrangeiro-form';
+  const salvarLabel = submitting ? 'Salvando...' : 'Salvar Operador';
 
   // Carregar dados auxiliares
   useEffect(() => {
@@ -464,19 +466,41 @@ const catalogoOptions = [
         ]} 
       />
 
-      <div className="mb-6 flex items-center gap-2">
-        <button 
-          onClick={voltar}
-          className="text-gray-400 hover:text-white transition-colors"
-        >
-          <ArrowLeft size={20} />
-        </button>
-        <h1 className="text-2xl font-semibold text-white">
-          {isNew ? 'Cadastrar Novo Operador Estrangeiro' : 'Editar Operador Estrangeiro'}
-        </h1>
+      <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={voltar}
+            className="text-gray-400 hover:text-white transition-colors"
+          >
+            <ArrowLeft size={20} />
+          </button>
+          <h1 className="text-2xl font-semibold text-white">
+            {isNew ? 'Cadastrar Novo Operador Estrangeiro' : 'Editar Operador Estrangeiro'}
+          </h1>
+        </div>
+        <div className="flex items-center gap-3 self-end md:self-auto">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={voltar}
+            disabled={submitting}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="submit"
+            form={formId}
+            variant="accent"
+            className="flex items-center gap-2"
+            disabled={submitting}
+          >
+            <Save size={16} />
+            {salvarLabel}
+          </Button>
+        </div>
       </div>
 
-      <form onSubmit={handleSubmit}>
+      <form id={formId} onSubmit={handleSubmit}>
         {/* Dados Básicos */}
         <Card className="mb-6" headerTitle="Dados Básicos">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -704,21 +728,22 @@ const catalogoOptions = [
         
         {/* Botões de Ação */}
         <div className="flex justify-end gap-3">
-          <Button 
-            type="button" 
+          <Button
+            type="button"
             variant="outline"
             onClick={voltar}
+            disabled={submitting}
           >
             Cancelar
           </Button>
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
             variant="accent"
             className="flex items-center gap-2"
             disabled={submitting}
           >
             <Save size={16} />
-            {submitting ? 'Salvando...' : 'Salvar Operador'}
+            {salvarLabel}
           </Button>
         </div>
       </form>

--- a/frontend/pages/produtos.tsx
+++ b/frontend/pages/produtos.tsx
@@ -12,7 +12,6 @@ import { LegendInfoModal } from '@/components/ui/LegendInfoModal';
 import { EnvironmentBadge } from '@/components/ui/EnvironmentBadge';
 import api from '@/lib/api';
 import { produtoStatusLegend, produtoSituacaoLegend } from '@/constants/statusLegends';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useToast } from '@/components/ui/ToastContext';
 import { useWorkingCatalog } from '@/contexts/WorkingCatalogContext';
@@ -295,13 +294,14 @@ export default function ProdutosPage() {
 
       <div className="mb-6 flex justify-between items-center">
         <h1 className="text-2xl font-semibold text-white">Lista de Produtos</h1>
-        <Link
-          href="/produtos/novo"
-          className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors"
+        <Button
+          variant="accent"
+          className="flex items-center gap-2"
+          onClick={() => router.push('/produtos/novo')}
         >
           <Plus size={16} />
           <span>Novo Produto</span>
-        </Link>
+        </Button>
       </div>
 
       {/* Filtros */}
@@ -389,10 +389,14 @@ export default function ProdutosPage() {
         {produtosFiltrados.length === 0 ? (
           <div className="text-center py-10">
             <p className="text-gray-400 mb-4">Nenhum produto encontrado.</p>
-            <Link href="/produtos/novo" className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors">
+            <Button
+              variant="accent"
+              className="inline-flex items-center gap-2"
+              onClick={() => router.push('/produtos/novo')}
+            >
               <Plus size={16} />
               <span>Adicionar Produto</span>
-            </Link>
+            </Button>
           </div>
         ) : (
           <div className="overflow-x-auto">

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -20,7 +20,7 @@ import {
   isValorPreenchido,
   normalizarValoresMultivalorados
 } from '@/lib/atributos';
-import { Trash2, BrainCog, ArrowLeft } from 'lucide-react';
+import { Trash2, BrainCog, ArrowLeft, Save } from 'lucide-react';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { useOperadorEstrangeiro, OperadorEstrangeiro } from '@/hooks/useOperadorEstrangeiro';
 import { OperadorEstrangeiroSelector } from '@/components/operadores-estrangeriros/OperadorEstrangeiroSelector';
@@ -683,13 +683,29 @@ export default function ProdutoPage() {
         ]}
       />
 
-      <div className="mb-6 flex items-center gap-2">
-        <button onClick={voltar} className="text-gray-400 hover:text-white transition-colors">
-          <ArrowLeft size={20} />
-        </button>
-        <h1 className="text-2xl font-semibold text-white">
-          {isNew ? 'Cadastrar Novo Produto' : 'Editar Produto'}
-        </h1>
+      <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-2">
+          <button onClick={voltar} className="text-gray-400 hover:text-white transition-colors">
+            <ArrowLeft size={20} />
+          </button>
+          <h1 className="text-2xl font-semibold text-white">
+            {isNew ? 'Cadastrar Novo Produto' : 'Editar Produto'}
+          </h1>
+        </div>
+        <div className="flex items-center gap-3 self-end md:self-auto">
+          <Button type="button" variant="outline" onClick={voltar}>
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            variant="accent"
+            className="flex items-center gap-2"
+            onClick={() => salvar()}
+          >
+            <Save size={16} />
+            Salvar Produto
+          </Button>
+        </div>
       </div>
 
       <Card className="mb-6 overflow-visible">
@@ -1026,11 +1042,19 @@ export default function ProdutoPage() {
                 <Button
                   type="button"
                   variant="outline"
-                  onClick={() => router.push('/produtos')}
+                  onClick={voltar}
                 >
                   Cancelar
                 </Button>
-                <Button type="button" onClick={() => salvar()}>Salvar Produto</Button>
+                <Button
+                  type="button"
+                  variant="accent"
+                  className="flex items-center gap-2"
+                  onClick={() => salvar()}
+                >
+                  <Save size={16} />
+                  Salvar Produto
+                </Button>
               </div>
             </>
           )}

--- a/frontend/pages/usuarios/[id].tsx
+++ b/frontend/pages/usuarios/[id].tsx
@@ -5,7 +5,7 @@ import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Save } from 'lucide-react';
 import { Toggle } from '@/components/ui/Toggle';
 import { PageLoader } from '@/components/ui/PageLoader';
 import { useAuth } from '@/contexts/AuthContext';
@@ -84,11 +84,26 @@ export default function EditarUsuarioPage() {
     <DashboardLayout title="Usuários">
       <Breadcrumb items={[{ label: 'Início', href: '/' }, { label: 'Usuários', href: '/usuarios' }, { label: usuario.nome }]} />
 
-      <div className="mb-6 flex items-center gap-2">
-        <button onClick={voltar} className="text-gray-400 hover:text-white transition-colors">
-          <ArrowLeft size={20} />
-        </button>
-        <h1 className="text-2xl font-semibold text-white">Editar Usuário</h1>
+      <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-2">
+          <button onClick={voltar} className="text-gray-400 hover:text-white transition-colors">
+            <ArrowLeft size={20} />
+          </button>
+          <h1 className="text-2xl font-semibold text-white">Editar Usuário</h1>
+        </div>
+        <div className="flex items-center gap-3 self-end md:self-auto">
+          <Button variant="outline" onClick={voltar}>
+            Cancelar
+          </Button>
+          <Button
+            variant="accent"
+            className="flex items-center gap-2"
+            onClick={salvar}
+          >
+            <Save size={16} />
+            Salvar
+          </Button>
+        </div>
       </div>
 
       <div className="space-y-6">
@@ -120,7 +135,14 @@ export default function EditarUsuarioPage() {
               ))}
             </Card>
           ))}
-          <Button onClick={salvar} className="mt-4">Salvar</Button>
+          <Button
+            onClick={salvar}
+            className="mt-4 flex items-center gap-2"
+            variant="accent"
+          >
+            <Save size={16} />
+            Salvar
+          </Button>
         </Card>
       </div>
     </DashboardLayout>


### PR DESCRIPTION
## Sumário
- Padronizei os botões de criação nas listagens de produtos e importações, adotando o estilo de destaque usado no restante do sistema.
- Adicionei ações de Cancelar/Salvar no topo dos formulários de cadastro/edição para catálogos, produtos, operadores estrangeiros, usuários, certificados e nova importação, mantendo os controles inferiores.

## Testes
- `npm run build:all`


------
https://chatgpt.com/codex/tasks/task_e_68dd8e3a19088330a5ff423f521f9b7c