### PR TITLE
Implementa processamento assíncrono da importação de produtos

### DIFF
--- a/backend/src/controllers/produto-importacao.controller.ts
+++ b/backend/src/controllers/produto-importacao.controller.ts
@@ -34,7 +34,11 @@ export async function importarProdutosPorPlanilha(req: Request, res: Response) {
       req.user?.id
     );
 
-    return res.status(201).json(importacao);
+    return res.status(202).json({
+      id: importacao.id,
+      situacao: importacao.situacao,
+      resultado: importacao.resultado
+    });
   } catch (error) {
     logger.error('Erro ao importar produtos via Excel:', error);
     if (error instanceof Error) {
@@ -48,6 +52,9 @@ export async function importarProdutosPorPlanilha(req: Request, res: Response) {
         error.message.includes('não possui dados')
       ) {
         return res.status(400).json({ error: error.message });
+      }
+      if (error.message.includes('Não foi possível iniciar o processamento')) {
+        return res.status(500).json({ error: error.message });
       }
     }
     return res.status(500).json({ error: 'Erro interno ao importar planilha' });

--- a/backend/src/jobs/produto-importacao.job.ts
+++ b/backend/src/jobs/produto-importacao.job.ts
@@ -1,0 +1,74 @@
+import { logger } from '../utils/logger';
+
+export interface ProdutoImportacaoJobData {
+  importacaoId: number;
+  superUserId: number;
+  usuarioCatalogoId: number | null;
+  catalogoId: number;
+  modalidade: string;
+  arquivo: {
+    nome: string;
+    conteudoBase64: string;
+  };
+}
+
+type ProdutoImportacaoProcessor = (data: ProdutoImportacaoJobData) => Promise<void>;
+
+const fila: ProdutoImportacaoJobData[] = [];
+let processor: ProdutoImportacaoProcessor | null = null;
+let processando = false;
+
+export function registerProdutoImportacaoProcessor(fn: ProdutoImportacaoProcessor) {
+  processor = fn;
+  if (fila.length > 0) {
+    iniciarProcessamento();
+  }
+}
+
+export async function enqueueProdutoImportacaoJob(data: ProdutoImportacaoJobData) {
+  fila.push(data);
+  iniciarProcessamento();
+}
+
+function iniciarProcessamento() {
+  if (processando) {
+    return;
+  }
+
+  processando = true;
+  setImmediate(processarProximo);
+}
+
+async function processarProximo() {
+  const proximo = fila.shift();
+
+  if (!proximo) {
+    processando = false;
+    return;
+  }
+
+  try {
+    if (!processor) {
+      throw new Error('Nenhum processador registrado para a fila de importação.');
+    }
+
+    await processor(proximo);
+  } catch (error) {
+    logger.error('Falha ao processar job de importação de produtos:', error);
+  } finally {
+    if (fila.length > 0) {
+      setImmediate(processarProximo);
+    } else {
+      processando = false;
+    }
+  }
+}
+
+export function getFilaTamanhoAtual() {
+  return fila.length;
+}
+
+export function limparFila() {
+  fila.length = 0;
+  processando = false;
+}

--- a/backend/src/services/__tests__/produto-importacao.service.test.ts
+++ b/backend/src/services/__tests__/produto-importacao.service.test.ts
@@ -1,0 +1,122 @@
+import { ProdutoImportacaoService } from '../produto-importacao.service';
+import { enqueueProdutoImportacaoJob } from '../../jobs/produto-importacao.job';
+import { ProdutoService } from '../produto.service';
+
+jest.mock('../../jobs/produto-importacao.job', () => ({
+  enqueueProdutoImportacaoJob: jest.fn().mockResolvedValue(undefined),
+  registerProdutoImportacaoProcessor: jest.fn(),
+}));
+
+const mockCatalogoPrisma = {
+  catalogo: { findFirst: jest.fn() },
+  usuarioCatalogo: { findFirst: jest.fn() },
+  importacaoProduto: {
+    create: jest.fn(),
+    update: jest.fn(),
+    findFirst: jest.fn(),
+  },
+  importacaoProdutoItem: { create: jest.fn() },
+  ncmCache: { findUnique: jest.fn() },
+  mensagem: { create: jest.fn() },
+} as any;
+
+jest.mock('../../utils/prisma', () => ({
+  catalogoPrisma: mockCatalogoPrisma,
+}));
+
+describe('ProdutoImportacaoService', () => {
+  let service: ProdutoImportacaoService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ProdutoImportacaoService();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('cria registro e enfileira job ao iniciar importação', async () => {
+    mockCatalogoPrisma.catalogo.findFirst.mockResolvedValue({
+      id: 1,
+      nome: 'Catálogo Teste',
+      numero: 123,
+    });
+    mockCatalogoPrisma.usuarioCatalogo.findFirst.mockResolvedValue({ id: 10 });
+    mockCatalogoPrisma.importacaoProduto.create.mockResolvedValue({
+      id: 55,
+      situacao: 'EM_ANDAMENTO',
+      resultado: 'PENDENTE',
+    });
+
+    const arquivoBase64 = Buffer.from('conteudo').toString('base64');
+
+    const resultado = await service.importarPlanilhaExcel(
+      {
+        catalogoId: 1,
+        modalidade: 'IMPORTACAO',
+        arquivo: { nome: 'produtos.xlsx', conteudoBase64: arquivoBase64 },
+      },
+      99,
+      77
+    );
+
+    expect(mockCatalogoPrisma.importacaoProduto.create).toHaveBeenCalledTimes(1);
+    expect(enqueueProdutoImportacaoJob).toHaveBeenCalledWith(
+      expect.objectContaining({ importacaoId: 55, catalogoId: 1, superUserId: 99 })
+    );
+    expect(resultado).toEqual(
+      expect.objectContaining({ id: 55, situacao: 'EM_ANDAMENTO', resultado: 'PENDENTE' })
+    );
+  });
+
+  it('processa job e atualiza totais ao concluir importação', async () => {
+    const arquivoBase64 = Buffer.from('conteudo').toString('base64');
+
+    mockCatalogoPrisma.catalogo.findFirst.mockResolvedValue({
+      id: 1,
+      nome: 'Catálogo Teste',
+      numero: 123,
+      cpf_cnpj: '00000000000',
+    });
+    mockCatalogoPrisma.ncmCache.findUnique.mockResolvedValue({ codigo: '12345678' });
+    mockCatalogoPrisma.importacaoProdutoItem.create.mockResolvedValue(undefined);
+    mockCatalogoPrisma.importacaoProduto.update.mockResolvedValue(undefined);
+    mockCatalogoPrisma.mensagem.create.mockResolvedValue(undefined);
+
+    jest
+      .spyOn(ProdutoService.prototype, 'criar')
+      .mockResolvedValue({ id: 999 } as any);
+    jest
+      .spyOn<any, any>(service as any, 'lerPlanilha')
+      .mockResolvedValue([
+        ['NCM', 'Nome', 'Codigos'],
+        ['12345678', 'Produto Teste', '123'],
+      ]);
+
+    await service.processarImportacaoJob({
+      importacaoId: 88,
+      superUserId: 99,
+      usuarioCatalogoId: 10,
+      catalogoId: 1,
+      modalidade: 'IMPORTACAO',
+      arquivo: { nome: 'produtos.xlsx', conteudoBase64: arquivoBase64 },
+    });
+
+    expect(mockCatalogoPrisma.importacaoProdutoItem.create).toHaveBeenCalledWith(
+      expect.objectContaining({ importacaoId: 88, linhaPlanilha: 2 })
+    );
+    expect(mockCatalogoPrisma.importacaoProduto.update).toHaveBeenCalledWith({
+      where: { id: 88 },
+      data: expect.objectContaining({
+        situacao: 'CONCLUIDA',
+        totalRegistros: 1,
+        totalCriados: 1,
+        totalComErro: 0,
+      }),
+    });
+    expect(mockCatalogoPrisma.mensagem.create).toHaveBeenCalledWith(
+      expect.objectContaining({ superUserId: 99 })
+    );
+  });
+});

--- a/frontend/pages/automacao/importar-produto/index.tsx
+++ b/frontend/pages/automacao/importar-produto/index.tsx
@@ -117,6 +117,19 @@ export default function ImportacoesPage() {
   const [limpandoHistorico, setLimpandoHistorico] = useState(false);
 
   const { addToast } = useToast();
+  const possuiProcessando = dados.some(importacao => importacao.situacao === 'EM_ANDAMENTO');
+
+  useEffect(() => {
+    if (!possuiProcessando) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      recarregar();
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [possuiProcessando, recarregar]);
 
   const removerImportacao = useCallback(
     async (id: number) => {
@@ -207,6 +220,11 @@ export default function ImportacoesPage() {
           </Button>
         </div>
       </div>
+      {possuiProcessando && (
+        <p className="mb-4 text-sm text-sky-300">
+          Há importações em andamento. A lista é atualizada automaticamente a cada 5 segundos.
+        </p>
+      )}
 
       {erro && (
         <Card className="mb-4 border border-red-500/40 bg-red-500/5 text-red-300">

--- a/frontend/pages/automacao/importar-produto/nova.tsx
+++ b/frontend/pages/automacao/importar-produto/nova.tsx
@@ -44,7 +44,7 @@ export default function NovaImportacaoPage() {
   const [erros, setErros] = useState<Record<string, string>>({});
   const isPlanilha = modalidadeImportacao === 'PLANILHA';
   const formId = 'nova-importacao-form';
-  const submitLabel = submetendo ? 'Importando...' : 'Iniciar importação';
+  const submitLabel = submetendo ? 'Iniciando...' : 'Iniciar importação';
 
   useEffect(() => {
     const carregarCatalogos = async () => {
@@ -134,14 +134,14 @@ export default function NovaImportacaoPage() {
 
     try {
       setSubmetendo(true);
-      const resposta = await api.post('/produtos/importacao', {
+      await api.post('/produtos/importacao', {
         catalogoId: Number(catalogoId),
         modalidade: modalidadeProduto,
         arquivo: arquivo,
       });
 
-      addToast('Importação concluída!', 'success');
-      router.push(`/automacao/importar-produto/${resposta.data.id}`);
+      addToast('Importação iniciada! Você será avisado quando terminar.', 'success');
+      router.push('/automacao/importar-produto');
     } catch (error: any) {
       console.error('Erro ao iniciar importação', error);
       const mensagem = error.response?.data?.error || 'Falha ao iniciar a importação.';


### PR DESCRIPTION
## Sumário
- cria fila em memória para orquestrar o processamento das importações de produtos em segundo plano
- adapta o serviço e o controller para agendar o trabalho e registrar a conclusão com os mesmos cálculos de antes
- atualiza o front-end para refletir o fluxo assíncrono, com feedback imediato, polling automático e destaque da situação
- adiciona testes unitários garantindo a criação do job e a atualização dos totais ao finalizar o processamento

## Testes
- npm run build:all
- npm test -- produto-importacao.service.test.ts *(falha: exige DATABASE_URL para executar as migrations do Prisma durante o globalSetup)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd9a364d48330a4a059c12836909e