### PR TITLE
feat: valores padrão por NCM

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   certificados Certificado[]
   mensagens    Mensagem[]
   importacoes  ImportacaoProduto[]
+  ncmValoresPadrao NcmValoresPadrao[]
 
   @@map("comex")
 }
@@ -340,6 +341,24 @@ model ProdutoAtributos {
   produto               Produto   @relation(fields: [produtoId], references: [id])
 
   @@map("produto_atributos")
+}
+
+model NcmValoresPadrao {
+  id                    Int      @id @default(autoincrement()) @map("id")
+  superUserId           Int      @map("super_user_id")
+  ncmCodigo             String   @map("ncm_codigo")
+  modalidade            String?  @map("modalidade")
+  valoresJson           Json     @map("valores_json")
+  estruturaSnapshotJson Json?    @map("estrutura_snapshot_json")
+  criadoEm              DateTime @default(now()) @map("criado_em")
+  atualizadoEm          DateTime @updatedAt @map("atualizado_em")
+  criadoPor             String?  @map("criado_por")
+  atualizadoPor         String?  @map("atualizado_por")
+
+  superUser User @relation(fields: [superUserId], references: [id])
+
+  @@unique([superUserId, ncmCodigo], name: "uk_superuser_ncm")
+  @@map("ncm_valores_padrao")
 }
 
 model CodigoInternoProduto {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -357,7 +357,7 @@ model NcmValoresPadrao {
 
   superUser User @relation(fields: [superUserId], references: [id])
 
-  @@unique([superUserId, ncmCodigo], name: "uk_superuser_ncm")
+  @@unique([superUserId, ncmCodigo, modalidade], name: "uk_superuser_ncm_modalidade")
   @@map("ncm_valores_padrao")
 }
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -23,8 +23,17 @@ const app = express();
 
 // Middleware básicos
 app.use(cors());
-app.use(json());
-app.use(urlencoded({ extended: true }));
+app.use(
+  json({
+    limit: '5mb'
+  })
+);
+app.use(
+  urlencoded({
+    extended: true,
+    limit: '5mb'
+  })
+);
 
 // Swagger para documentação da API
 setupSwagger(app);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -17,6 +17,7 @@ import { Router } from 'express';
 import { API_PREFIX } from './config';
 import uploadRoutes from './routes/upload.routes';
 import mensagemRoutes from './routes/mensagem.routes';
+import ncmValoresPadraoRoutes from './routes/ncm-valores-padrao.routes';
 
 const app = express();
 
@@ -49,6 +50,9 @@ apiRouter.use('/operadores-estrangeiros', operadorEstrangeiroRoutes);
 
 // Rotas de produtos (protegidas)
 apiRouter.use('/produtos', produtoRoutes);
+
+// Rotas de valores padrão por NCM (protegidas)
+apiRouter.use('/ncm-valores-padrao', ncmValoresPadraoRoutes);
 
 // Rotas de usuários (protegidas)
 apiRouter.use('/usuarios', usuarioRoutes);

--- a/backend/src/controllers/ncm-valores-padrao.controller.ts
+++ b/backend/src/controllers/ncm-valores-padrao.controller.ts
@@ -1,0 +1,115 @@
+// backend/src/controllers/ncm-valores-padrao.controller.ts
+import { Request, Response } from 'express';
+import { NcmValoresPadraoService } from '../services/ncm-valores-padrao.service';
+import { logger } from '../utils/logger';
+
+const service = new NcmValoresPadraoService();
+
+export async function listarValoresPadrao(req: Request, res: Response) {
+  try {
+    const registros = await service.listar(req.user!.superUserId);
+    res.json(registros);
+  } catch (error: any) {
+    logger.error('Erro ao listar valores padrão de NCM', error);
+    res.status(500).json({ error: 'Erro ao listar valores padrão de NCM' });
+  }
+}
+
+export async function obterValorPadrao(req: Request, res: Response) {
+  try {
+    const id = Number(req.params.id);
+    const registro = await service.buscarPorId(id, req.user!.superUserId);
+    if (!registro) {
+      return res.status(404).json({ error: 'Grupo de valores padrão não encontrado' });
+    }
+    res.json(registro);
+  } catch (error: any) {
+    logger.error('Erro ao buscar valor padrão de NCM', error);
+    res.status(500).json({ error: 'Erro ao buscar valor padrão de NCM' });
+  }
+}
+
+export async function buscarValorPadraoPorNcm(req: Request, res: Response) {
+  try {
+    const ncmCodigo = req.params.ncmCodigo;
+    const modalidade = (req.query.modalidade as string | undefined) || undefined;
+    const registro = await service.buscarPorNcm(ncmCodigo, req.user!.superUserId);
+    if (!registro) {
+      return res.status(404).json({ error: 'Valores padrão não encontrados para esta NCM' });
+    }
+    if (
+      modalidade &&
+      registro.modalidade &&
+      registro.modalidade.toUpperCase() !== modalidade.toUpperCase()
+    ) {
+      return res.status(404).json({ error: 'Valores padrão não encontrados para esta modalidade' });
+    }
+    res.json(registro);
+  } catch (error: any) {
+    logger.error('Erro ao buscar valores padrão por NCM', error);
+    res.status(500).json({ error: 'Erro ao buscar valores padrão por NCM' });
+  }
+}
+
+export async function criarValorPadrao(req: Request, res: Response) {
+  try {
+    const registro = await service.criar(
+      {
+        ncmCodigo: req.body.ncmCodigo,
+        modalidade: req.body.modalidade,
+        valoresAtributos: req.body.valoresAtributos,
+        estruturaSnapshot: req.body.estruturaSnapshot
+      },
+      req.user!.superUserId,
+      { nome: req.user!.name }
+    );
+    res.status(201).json(registro);
+  } catch (error: any) {
+    if (error.message?.includes('Já existe um valor padrão')) {
+      return res.status(400).json({ error: error.message });
+    }
+    logger.error('Erro ao criar valor padrão de NCM', error);
+    res.status(500).json({ error: 'Erro ao criar valor padrão de NCM' });
+  }
+}
+
+export async function atualizarValorPadrao(req: Request, res: Response) {
+  try {
+    const id = Number(req.params.id);
+    const registro = await service.atualizar(
+      id,
+      {
+        ncmCodigo: req.body.ncmCodigo,
+        modalidade: req.body.modalidade,
+        valoresAtributos: req.body.valoresAtributos,
+        estruturaSnapshot: req.body.estruturaSnapshot
+      },
+      req.user!.superUserId,
+      { nome: req.user!.name }
+    );
+    res.json(registro);
+  } catch (error: any) {
+    if (error.message?.includes('não encontrado')) {
+      return res.status(404).json({ error: error.message });
+    }
+    if (error.message?.includes('Já existe um valor padrão')) {
+      return res.status(400).json({ error: error.message });
+    }
+    logger.error('Erro ao atualizar valor padrão de NCM', error);
+    res.status(500).json({ error: 'Erro ao atualizar valor padrão de NCM' });
+  }
+}
+
+export async function removerValorPadrao(req: Request, res: Response) {
+  try {
+    const id = Number(req.params.id);
+    await service.remover(id, req.user!.superUserId);
+    res.status(204).send();
+  } catch (error: any) {
+    if (error.message?.includes('não encontrado')) {
+      return res.status(404).json({ error: error.message });
+    }
+    logger.error('Erro ao remover valor padrão de NCM', error);
+    res.status(500).json({ error: 'Erro ao remover valor padrão de NCM' });
+  }
+}

--- a/backend/src/controllers/ncm-valores-padrao.controller.ts
+++ b/backend/src/controllers/ncm-valores-padrao.controller.ts
@@ -33,16 +33,13 @@ export async function buscarValorPadraoPorNcm(req: Request, res: Response) {
   try {
     const ncmCodigo = req.params.ncmCodigo;
     const modalidade = (req.query.modalidade as string | undefined) || undefined;
-    const registro = await service.buscarPorNcm(ncmCodigo, req.user!.superUserId);
+    const registro = await service.buscarPorNcm(
+      ncmCodigo,
+      req.user!.superUserId,
+      modalidade ?? null
+    );
     if (!registro) {
-      return res.status(404).json({ error: 'Valores padrão não encontrados para esta NCM' });
-    }
-    if (
-      modalidade &&
-      registro.modalidade &&
-      registro.modalidade.toUpperCase() !== modalidade.toUpperCase()
-    ) {
-      return res.status(404).json({ error: 'Valores padrão não encontrados para esta modalidade' });
+      return res.status(404).json({ error: 'Valores padrão não encontrados para esta NCM e modalidade' });
     }
     res.json(registro);
   } catch (error: any) {

--- a/backend/src/routes/ncm-valores-padrao.routes.ts
+++ b/backend/src/routes/ncm-valores-padrao.routes.ts
@@ -1,0 +1,29 @@
+// backend/src/routes/ncm-valores-padrao.routes.ts
+import { Router } from 'express';
+import { authMiddleware } from '../middlewares/auth.middleware';
+import { validate } from '../middlewares/validate.middleware';
+import {
+  listarValoresPadrao,
+  obterValorPadrao,
+  buscarValorPadraoPorNcm,
+  criarValorPadrao,
+  atualizarValorPadrao,
+  removerValorPadrao
+} from '../controllers/ncm-valores-padrao.controller';
+import {
+  createNcmValoresPadraoSchema,
+  updateNcmValoresPadraoSchema
+} from '../validators/ncm-valores-padrao.validator';
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.get('/', listarValoresPadrao);
+router.get('/ncm/:ncmCodigo', buscarValorPadraoPorNcm);
+router.get('/:id', obterValorPadrao);
+router.post('/', validate(createNcmValoresPadraoSchema), criarValorPadrao);
+router.put('/:id', validate(updateNcmValoresPadraoSchema), atualizarValorPadrao);
+router.delete('/:id', removerValorPadrao);
+
+export default router;

--- a/backend/src/services/ncm-valores-padrao.service.ts
+++ b/backend/src/services/ncm-valores-padrao.service.ts
@@ -1,0 +1,105 @@
+// backend/src/services/ncm-valores-padrao.service.ts
+import { Prisma } from '@prisma/client';
+import { catalogoPrisma } from '../utils/prisma';
+
+export interface NcmValoresPadraoInput {
+  ncmCodigo: string;
+  modalidade?: string | null;
+  valoresAtributos?: Prisma.InputJsonValue;
+  estruturaSnapshot?: Prisma.InputJsonValue;
+}
+
+export class NcmValoresPadraoService {
+  async listar(superUserId: number) {
+    return catalogoPrisma.ncmValoresPadrao.findMany({
+      where: { superUserId },
+      orderBy: [{ atualizadoEm: 'desc' }, { ncmCodigo: 'asc' }]
+    });
+  }
+
+  async buscarPorId(id: number, superUserId: number) {
+    return catalogoPrisma.ncmValoresPadrao.findFirst({
+      where: { id, superUserId }
+    });
+  }
+
+  async buscarPorNcm(ncmCodigo: string, superUserId: number) {
+    return catalogoPrisma.ncmValoresPadrao.findFirst({
+      where: { ncmCodigo, superUserId }
+    });
+  }
+
+  async criar(
+    dados: NcmValoresPadraoInput,
+    superUserId: number,
+    usuario?: { nome?: string }
+  ) {
+    const existente = await catalogoPrisma.ncmValoresPadrao.findFirst({
+      where: { ncmCodigo: dados.ncmCodigo, superUserId }
+    });
+    if (existente) {
+      throw new Error('Já existe um valor padrão cadastrado para esta NCM');
+    }
+
+    return catalogoPrisma.ncmValoresPadrao.create({
+      data: {
+        superUserId,
+        ncmCodigo: dados.ncmCodigo,
+        modalidade: dados.modalidade ?? null,
+        valoresJson: (dados.valoresAtributos ?? {}) as Prisma.InputJsonValue,
+        estruturaSnapshotJson: dados.estruturaSnapshot ?? Prisma.JsonNull,
+        criadoPor: usuario?.nome || null,
+        atualizadoPor: usuario?.nome || null
+      }
+    });
+  }
+
+  async atualizar(
+    id: number,
+    dados: NcmValoresPadraoInput,
+    superUserId: number,
+    usuario?: { nome?: string }
+  ) {
+    const existente = await catalogoPrisma.ncmValoresPadrao.findFirst({
+      where: { id, superUserId }
+    });
+    if (!existente) {
+      throw new Error('Grupo de valores padrão não encontrado');
+    }
+
+    if (dados.ncmCodigo && dados.ncmCodigo !== existente.ncmCodigo) {
+      const duplicado = await catalogoPrisma.ncmValoresPadrao.findFirst({
+        where: {
+          superUserId,
+          ncmCodigo: dados.ncmCodigo,
+          NOT: { id }
+        }
+      });
+      if (duplicado) {
+        throw new Error('Já existe um valor padrão cadastrado para esta NCM');
+      }
+    }
+
+    return catalogoPrisma.ncmValoresPadrao.update({
+      where: { id },
+      data: {
+        ncmCodigo: dados.ncmCodigo,
+        modalidade: dados.modalidade ?? null,
+        valoresJson: (dados.valoresAtributos ?? {}) as Prisma.InputJsonValue,
+        estruturaSnapshotJson: dados.estruturaSnapshot ?? Prisma.JsonNull,
+        atualizadoPor: usuario?.nome || null
+      }
+    });
+  }
+
+  async remover(id: number, superUserId: number) {
+    const existente = await catalogoPrisma.ncmValoresPadrao.findFirst({
+      where: { id, superUserId }
+    });
+    if (!existente) {
+      throw new Error('Grupo de valores padrão não encontrado');
+    }
+
+    await catalogoPrisma.ncmValoresPadrao.delete({ where: { id } });
+  }
+}

--- a/backend/src/services/ncm-valores-padrao.service.ts
+++ b/backend/src/services/ncm-valores-padrao.service.ts
@@ -30,9 +30,14 @@ export class NcmValoresPadraoService {
     });
   }
 
-  async buscarPorNcm(ncmCodigo: string, superUserId: number) {
+  async buscarPorNcm(ncmCodigo: string, superUserId: number, modalidade?: string | null) {
+    const modalidadeNormalizada = modalidade?.toUpperCase() ?? null;
     return catalogoPrisma.ncmValoresPadrao.findFirst({
-      where: { ncmCodigo, superUserId }
+      where: {
+        ncmCodigo,
+        superUserId,
+        modalidade: modalidadeNormalizada
+      }
     });
   }
 
@@ -41,18 +46,23 @@ export class NcmValoresPadraoService {
     superUserId: number,
     usuario?: { nome?: string }
   ) {
+    const modalidadeNormalizada = dados.modalidade?.toUpperCase() ?? null;
     const existente = await catalogoPrisma.ncmValoresPadrao.findFirst({
-      where: { ncmCodigo: dados.ncmCodigo, superUserId }
+      where: {
+        ncmCodigo: dados.ncmCodigo,
+        superUserId,
+        modalidade: modalidadeNormalizada
+      }
     });
     if (existente) {
-      throw new Error('Já existe um valor padrão cadastrado para esta NCM');
+      throw new Error('Já existe um valor padrão cadastrado para esta NCM e modalidade');
     }
 
     return catalogoPrisma.ncmValoresPadrao.create({
       data: {
         superUserId,
         ncmCodigo: dados.ncmCodigo,
-        modalidade: dados.modalidade ?? null,
+        modalidade: modalidadeNormalizada,
         valoresJson: (dados.valoresAtributos ?? {}) as Prisma.InputJsonValue,
         estruturaSnapshotJson: dados.estruturaSnapshot ?? Prisma.JsonNull,
         criadoPor: usuario?.nome || null,
@@ -78,7 +88,7 @@ export class NcmValoresPadraoService {
       throw new Error('Não é permitido alterar a NCM do valor padrão');
     }
 
-    if (dados.modalidade && dados.modalidade !== existente.modalidade) {
+    if (dados.modalidade && dados.modalidade.toUpperCase() !== existente.modalidade) {
       throw new Error('Não é permitido alterar a modalidade do valor padrão');
     }
 

--- a/backend/src/services/ncm-valores-padrao.service.ts
+++ b/backend/src/services/ncm-valores-padrao.service.ts
@@ -2,8 +2,15 @@
 import { Prisma } from '@prisma/client';
 import { catalogoPrisma } from '../utils/prisma';
 
-export interface NcmValoresPadraoInput {
+export interface NcmValoresPadraoCreateInput {
   ncmCodigo: string;
+  modalidade?: string | null;
+  valoresAtributos?: Prisma.InputJsonValue;
+  estruturaSnapshot?: Prisma.InputJsonValue;
+}
+
+export interface NcmValoresPadraoUpdateInput {
+  ncmCodigo?: string;
   modalidade?: string | null;
   valoresAtributos?: Prisma.InputJsonValue;
   estruturaSnapshot?: Prisma.InputJsonValue;
@@ -30,7 +37,7 @@ export class NcmValoresPadraoService {
   }
 
   async criar(
-    dados: NcmValoresPadraoInput,
+    dados: NcmValoresPadraoCreateInput,
     superUserId: number,
     usuario?: { nome?: string }
   ) {
@@ -56,7 +63,7 @@ export class NcmValoresPadraoService {
 
   async atualizar(
     id: number,
-    dados: NcmValoresPadraoInput,
+    dados: NcmValoresPadraoUpdateInput,
     superUserId: number,
     usuario?: { nome?: string }
   ) {
@@ -68,23 +75,16 @@ export class NcmValoresPadraoService {
     }
 
     if (dados.ncmCodigo && dados.ncmCodigo !== existente.ncmCodigo) {
-      const duplicado = await catalogoPrisma.ncmValoresPadrao.findFirst({
-        where: {
-          superUserId,
-          ncmCodigo: dados.ncmCodigo,
-          NOT: { id }
-        }
-      });
-      if (duplicado) {
-        throw new Error('Já existe um valor padrão cadastrado para esta NCM');
-      }
+      throw new Error('Não é permitido alterar a NCM do valor padrão');
+    }
+
+    if (dados.modalidade && dados.modalidade !== existente.modalidade) {
+      throw new Error('Não é permitido alterar a modalidade do valor padrão');
     }
 
     return catalogoPrisma.ncmValoresPadrao.update({
       where: { id },
       data: {
-        ncmCodigo: dados.ncmCodigo,
-        modalidade: dados.modalidade ?? null,
         valoresJson: (dados.valoresAtributos ?? {}) as Prisma.InputJsonValue,
         estruturaSnapshotJson: dados.estruturaSnapshot ?? Prisma.JsonNull,
         atualizadoPor: usuario?.nome || null

--- a/backend/src/validators/ncm-valores-padrao.validator.ts
+++ b/backend/src/validators/ncm-valores-padrao.validator.ts
@@ -1,0 +1,16 @@
+// backend/src/validators/ncm-valores-padrao.validator.ts
+import { z } from 'zod';
+
+export const createNcmValoresPadraoSchema = z.object({
+  ncmCodigo: z.string().length(8),
+  modalidade: z.string().min(1).optional(),
+  valoresAtributos: z.record(z.any()).optional(),
+  estruturaSnapshot: z.any().optional()
+});
+
+export const updateNcmValoresPadraoSchema = z.object({
+  ncmCodigo: z.string().length(8),
+  modalidade: z.string().min(1).optional(),
+  valoresAtributos: z.record(z.any()).optional(),
+  estruturaSnapshot: z.any().optional()
+});

--- a/backend/src/validators/ncm-valores-padrao.validator.ts
+++ b/backend/src/validators/ncm-valores-padrao.validator.ts
@@ -9,7 +9,7 @@ export const createNcmValoresPadraoSchema = z.object({
 });
 
 export const updateNcmValoresPadraoSchema = z.object({
-  ncmCodigo: z.string().length(8),
+  ncmCodigo: z.string().length(8).optional(),
   modalidade: z.string().min(1).optional(),
   valoresAtributos: z.record(z.any()).optional(),
   estruturaSnapshot: z.any().optional()

--- a/docs/sql/2025-03-27_ncm_valores_padrao.sql
+++ b/docs/sql/2025-03-27_ncm_valores_padrao.sql
@@ -1,0 +1,17 @@
+-- Criação da tabela de valores padrão por NCM
+CREATE TABLE IF NOT EXISTS ncm_valores_padrao (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    super_user_id INT UNSIGNED NOT NULL,
+    ncm_codigo VARCHAR(8) NOT NULL,
+    modalidade VARCHAR(20) NULL,
+    valores_json JSON NOT NULL,
+    estrutura_snapshot_json JSON NULL,
+    criado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    atualizado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    criado_por VARCHAR(255) NULL,
+    atualizado_por VARCHAR(255) NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_superuser_ncm (super_user_id, ncm_codigo),
+    INDEX idx_ncm_valores_padrao_super_user (super_user_id),
+    CONSTRAINT fk_ncm_valores_padrao_super_user FOREIGN KEY (super_user_id) REFERENCES comex(idv32)
+);

--- a/docs/sql/2025-03-27_ncm_valores_padrao.sql
+++ b/docs/sql/2025-03-27_ncm_valores_padrao.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS ncm_valores_padrao (
     criado_por VARCHAR(255) NULL,
     atualizado_por VARCHAR(255) NULL,
     PRIMARY KEY (id),
-    UNIQUE KEY uk_superuser_ncm (super_user_id, ncm_codigo),
+    UNIQUE KEY uk_superuser_ncm_modalidade (super_user_id, ncm_codigo, modalidade),
     -- Integridade com o superusuário mantida via aplicação, pois a tabela comex está em outro schema
     INDEX idx_ncm_valores_padrao_super_user (super_user_id)
 );

--- a/docs/sql/2025-03-27_ncm_valores_padrao.sql
+++ b/docs/sql/2025-03-27_ncm_valores_padrao.sql
@@ -12,6 +12,6 @@ CREATE TABLE IF NOT EXISTS ncm_valores_padrao (
     atualizado_por VARCHAR(255) NULL,
     PRIMARY KEY (id),
     UNIQUE KEY uk_superuser_ncm (super_user_id, ncm_codigo),
-    INDEX idx_ncm_valores_padrao_super_user (super_user_id),
-    CONSTRAINT fk_ncm_valores_padrao_super_user FOREIGN KEY (super_user_id) REFERENCES comex(idv32)
+    -- Integridade com o superusuário mantida via aplicação, pois a tabela comex está em outro schema
+    INDEX idx_ncm_valores_padrao_super_user (super_user_id)
 );

--- a/docs/sql/2025-03-27_ncm_valores_padrao.sql
+++ b/docs/sql/2025-03-27_ncm_valores_padrao.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS ncm_valores_padrao (
     id INT UNSIGNED NOT NULL AUTO_INCREMENT,
     super_user_id INT UNSIGNED NOT NULL,
     ncm_codigo VARCHAR(8) NOT NULL,
-    modalidade VARCHAR(20) NULL,
+    modalidade VARCHAR(10) NULL,
     valores_json JSON NOT NULL,
     estrutura_snapshot_json JSON NULL,
     criado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -110,7 +110,7 @@ export function Sidebar({ onToggle, isCollapsed }: SidebarProps) {
         { label: 'Importar Produto', href: '/automacao/importar-produto' },
         // { label: 'Preencher Atributos em Massa', href: '/automacao/preencher-atributos-em-massa' },
         // { label: 'Ajuste de Produtos em Massa', href: '/automacao/ajuste-de-produtos-em-massa' },
-        // { label: 'Definir Valor de Atributo Padrão', href: '/automacao/definir-valor-de-atributo-padrao' },
+        // { label: 'Definir Valor de Atributo Padrão', href: '/produtos/valores-padrao' },
       ],
     },
   ];

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -92,7 +92,6 @@ export function Sidebar({ onToggle, isCollapsed }: SidebarProps) {
       label: 'Produtos',
       subItems: [
         { label: 'Produtos', href: '/produtos', hideWhenExpanded: true  },
-        { label: 'Valores Padrão por NCM', href: '/produtos/valores-padrao' },
       ],
     },
     {
@@ -108,9 +107,9 @@ export function Sidebar({ onToggle, isCollapsed }: SidebarProps) {
       subItems: [
         { label: 'Automação', hideWhenExpanded: true },
         { label: 'Importar Produto', href: '/automacao/importar-produto' },
+        { label: 'Definir Valor de Atributo Padrão', href: '/produtos/valores-padrao' },
         // { label: 'Preencher Atributos em Massa', href: '/automacao/preencher-atributos-em-massa' },
         // { label: 'Ajuste de Produtos em Massa', href: '/automacao/ajuste-de-produtos-em-massa' },
-        // { label: 'Definir Valor de Atributo Padrão', href: '/produtos/valores-padrao' },
       ],
     },
   ];

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -92,6 +92,7 @@ export function Sidebar({ onToggle, isCollapsed }: SidebarProps) {
       label: 'Produtos',
       subItems: [
         { label: 'Produtos', href: '/produtos', hideWhenExpanded: true  },
+        { label: 'Valores Padrão por NCM', href: '/produtos/valores-padrao' },
       ],
     },
     {

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -192,6 +192,9 @@ export default function ProdutoPage() {
         setNcmDescricao('');
         setUnidadeMedida('');
         setEstrutura([]);
+        if (isNew) {
+          setValores({});
+        }
         return;
       }
 
@@ -199,6 +202,21 @@ export default function ProdutoPage() {
       setNcmDescricao(response.data.descricaoNcm);
       setUnidadeMedida(response.data.unidadeMedida || '');
       setEstrutura(ordenarAtributos(dados));
+      if (isNew) {
+        try {
+          const templateResponse = await api.get(
+            `/ncm-valores-padrao/ncm/${ncmCodigo}`,
+            { params: { modalidade } }
+          );
+          const valoresPadrao = (templateResponse.data?.valoresJson || {}) as Record<string, string | string[]>;
+          setValores(valoresPadrao);
+        } catch (error: any) {
+          if (error?.response?.status !== 404) {
+            console.error('Erro ao carregar valores padrão da NCM:', error);
+          }
+          setValores({});
+        }
+      }
       setEstruturaCarregada(true);
     } catch (error) {
       console.error('Erro ao carregar atributos:', error);
@@ -224,6 +242,9 @@ export default function ProdutoPage() {
       setCarregandoSugestoesNcm(false);
     }
     if (valor.length === 8) {
+      if (isNew) {
+        setValores({});
+      }
       carregarEstrutura(valor);
     } else {
       setNcmDescricao('');

--- a/frontend/pages/produtos/valores-padrao/[id].tsx
+++ b/frontend/pages/produtos/valores-padrao/[id].tsx
@@ -521,31 +521,58 @@ export default function ValoresPadraoNcmPage() {
         </div>
       </div>
 
-      <Card className="mb-6">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <MaskedInput
-            label="NCM"
-            mask="ncm"
-            value={ncm}
-            onChange={handleNcmChange}
-            className="mb-0 md:max-w-[9rem]"
-            required
-            disabled={loading || camposBloqueados}
-            onFocus={() => {
-              if (
-                !camposBloqueados &&
-                ncm.length >= 4 &&
-                ncm.length < 8 &&
-                ncmSugestoes.length > 0
-              ) {
-                setMostrarSugestoesNcm(true);
-              }
-            }}
-            onBlur={() => {
-              setTimeout(() => setMostrarSugestoesNcm(false), 100);
-            }}
-            autoComplete="off"
-          />
+      <Card className="mb-6 overflow-visible">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-[9rem_11rem_10rem_minmax(0,1fr)]">
+          <div className="relative">
+            <MaskedInput
+              label="NCM"
+              mask="ncm"
+              value={ncm}
+              onChange={handleNcmChange}
+              className="md:mb-0"
+              required
+              disabled={loading || camposBloqueados}
+              onFocus={() => {
+                if (
+                  !camposBloqueados &&
+                  ncm.length >= 4 &&
+                  ncm.length < 8 &&
+                  ncmSugestoes.length > 0
+                ) {
+                  setMostrarSugestoesNcm(true);
+                }
+              }}
+              onBlur={() => {
+                setTimeout(() => setMostrarSugestoesNcm(false), 100);
+              }}
+              autoComplete="off"
+            />
+
+            {(carregandoSugestoesNcm || mostrarSugestoesNcm) && ncm.length < 8 && isNew && (
+              <div className="absolute left-0 right-0 z-20 mt-1 max-h-64 md:max-h-80 overflow-y-auto rounded-md border border-gray-700 bg-[#1e2126] shadow-lg">
+                {carregandoSugestoesNcm ? (
+                  <div className="px-3 py-2 text-sm text-gray-400">Buscando sugestões...</div>
+                ) : ncmSugestoes.length === 0 ? (
+                  <div className="px-3 py-2 text-sm text-gray-400">Nenhuma sugestão encontrada</div>
+                ) : (
+                  ncmSugestoes.map(sugestao => (
+                    <button
+                      key={sugestao.codigo}
+                      type="button"
+                      className="flex w-full flex-col items-start px-3 py-2 text-left text-sm text-gray-100 hover:bg-gray-700"
+                      onMouseDown={event => event.preventDefault()}
+                      onClick={() => selecionarSugestaoNcm(sugestao)}
+                    >
+                      <span className="font-medium">{formatarNCMExibicao(sugestao.codigo)}</span>
+                      {sugestao.descricao && (
+                        <span className="text-xs text-gray-400">{sugestao.descricao}</span>
+                      )}
+                    </button>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
           <Select
             label="Modalidade"
             options={[
@@ -562,44 +589,22 @@ export default function ValoresPadraoNcmPage() {
               }
             }}
             disabled={camposBloqueados}
-            className="md:max-w-[10rem]"
+            className="md:mb-0 md:w-[11rem]"
           />
-          <Input label="Descrição NCM" value={ncmDescricao} disabled className="md:col-span-2" />
           <Input
             label="Unidade de Medida"
             value={unidadeMedida}
             disabled
-            className="md:max-w-[10rem]"
+            className="md:mb-0 md:w-[10rem]"
             maxLength={10}
           />
+          <Input
+            label="Descrição NCM"
+            value={ncmDescricao}
+            disabled
+            className="md:mb-0"
+          />
         </div>
-
-        {(carregandoSugestoesNcm || mostrarSugestoesNcm) && ncm.length < 8 && isNew && (
-          <div className="relative">
-            <div className="absolute left-0 right-0 top-full z-20 mt-1 max-h-64 md:max-h-80 overflow-y-auto rounded-md border border-gray-700 bg-[#1e2126] shadow-lg">
-              {carregandoSugestoesNcm ? (
-                <div className="px-3 py-2 text-sm text-gray-400">Buscando sugestões...</div>
-              ) : ncmSugestoes.length === 0 ? (
-                <div className="px-3 py-2 text-sm text-gray-400">Nenhuma sugestão encontrada</div>
-              ) : (
-                ncmSugestoes.map(sugestao => (
-                  <button
-                    key={sugestao.codigo}
-                    type="button"
-                    className="flex w-full flex-col items-start px-3 py-2 text-left text-sm text-gray-100 hover:bg-gray-700"
-                    onMouseDown={event => event.preventDefault()}
-                    onClick={() => selecionarSugestaoNcm(sugestao)}
-                  >
-                    <span className="font-medium">{formatarNCMExibicao(sugestao.codigo)}</span>
-                    {sugestao.descricao && (
-                      <span className="text-xs text-gray-400">{sugestao.descricao}</span>
-                    )}
-                  </button>
-                ))
-              )}
-            </div>
-          </div>
-        )}
       </Card>
 
       {erroFormulario && (

--- a/frontend/pages/produtos/valores-padrao/[id].tsx
+++ b/frontend/pages/produtos/valores-padrao/[id].tsx
@@ -1,0 +1,608 @@
+// frontend/pages/produtos/valores-padrao/[id].tsx
+import React, { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+import { Breadcrumb } from '@/components/ui/Breadcrumb';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { MaskedInput } from '@/components/ui/MaskedInput';
+import { Select } from '@/components/ui/Select';
+import { MultiSelect } from '@/components/ui/MultiSelect';
+import { RadioGroup } from '@/components/ui/RadioGroup';
+import { Hint } from '@/components/ui/Hint';
+import { useToast } from '@/components/ui/ToastContext';
+import api from '@/lib/api';
+import { algumValorIgual, algumValorSatisfazCondicao, isValorPreenchido, normalizarValoresMultivalorados } from '@/lib/atributos';
+import { PageLoader } from '@/components/ui/PageLoader';
+import useDebounce from '@/hooks/useDebounce';
+import { ArrowLeft, Save } from 'lucide-react';
+
+interface AtributoEstrutura {
+  codigo: string;
+  nome: string;
+  tipo: string;
+  obrigatorio: boolean;
+  multivalorado?: boolean;
+  dominio?: { codigo: string; descricao: string }[];
+  validacoes?: {
+    tamanho_maximo?: number;
+    mascara?: string;
+    [key: string]: any;
+  };
+  descricaoCondicao?: string;
+  condicao?: any;
+  parentCodigo?: string;
+  condicionanteCodigo?: string;
+  orientacaoPreenchimento?: string;
+  subAtributos?: AtributoEstrutura[];
+}
+
+interface NcmValorPadraoDetalhe {
+  id: number;
+  ncmCodigo: string;
+  modalidade?: string | null;
+  valoresJson: Record<string, string | string[]> | null;
+  estruturaSnapshotJson?: AtributoEstrutura[];
+}
+
+export default function ValoresPadraoNcmPage() {
+  const router = useRouter();
+  const { addToast } = useToast();
+  const { id } = router.query;
+  const isNew = !id || id === 'novo';
+
+  const [ncm, setNcm] = useState('');
+  const [ncmDescricao, setNcmDescricao] = useState('');
+  const [unidadeMedida, setUnidadeMedida] = useState('');
+  const [modalidade, setModalidade] = useState<'IMPORTACAO' | 'EXPORTACAO'>('IMPORTACAO');
+  const [estrutura, setEstrutura] = useState<AtributoEstrutura[]>([]);
+  const [valores, setValores] = useState<Record<string, string | string[]>>({});
+  const [loading, setLoading] = useState(false);
+  const [loadingEstrutura, setLoadingEstrutura] = useState(false);
+  const [estruturaCarregada, setEstruturaCarregada] = useState(false);
+  const [ncmSugestoes, setNcmSugestoes] = useState<Array<{ codigo: string; descricao: string | null }>>([]);
+  const [mostrarSugestoesNcm, setMostrarSugestoesNcm] = useState(false);
+  const [carregandoSugestoesNcm, setCarregandoSugestoesNcm] = useState(false);
+  const debouncedNcm = useDebounce(ncm, 800);
+  const [erroFormulario, setErroFormulario] = useState<string | null>(null);
+
+  const mapaEstrutura = useMemo(() => {
+    const map = new Map<string, AtributoEstrutura>();
+    function coletar(lista: AtributoEstrutura[]) {
+      for (const a of lista) {
+        map.set(a.codigo, a);
+        if (a.subAtributos) coletar(a.subAtributos);
+      }
+    }
+    coletar(estrutura);
+    return map;
+  }, [estrutura]);
+
+  useEffect(() => {
+    if (!router.isReady || isNew || typeof id !== 'string') return;
+    carregarRegistro(id);
+  }, [router.isReady, id, isNew]);
+
+  useEffect(() => {
+    if (debouncedNcm.length >= 4 && debouncedNcm.length < 8) {
+      let ativo = true;
+      setCarregandoSugestoesNcm(true);
+      setMostrarSugestoesNcm(true);
+
+      api
+        .get('/siscomex/ncm/sugestoes', { params: { prefixo: debouncedNcm } })
+        .then(response => {
+          if (!ativo) return;
+          const lista = (response.data?.dados as Array<{ codigo: string; descricao: string | null }> | undefined) || [];
+          setNcmSugestoes(lista);
+          setMostrarSugestoesNcm(true);
+        })
+        .catch(error => {
+          if (!ativo) return;
+          console.error('Erro ao buscar sugestões de NCM:', error);
+          setMostrarSugestoesNcm(false);
+          setNcmSugestoes([]);
+        })
+        .finally(() => {
+          if (!ativo) return;
+          setCarregandoSugestoesNcm(false);
+        });
+
+      return () => {
+        ativo = false;
+      };
+    }
+
+    setNcmSugestoes([]);
+    setMostrarSugestoesNcm(false);
+    setCarregandoSugestoesNcm(false);
+  }, [debouncedNcm]);
+
+  useEffect(() => {
+    if (!estruturaCarregada || !estrutura.length) return;
+    setErroFormulario(null);
+  }, [estruturaCarregada, estrutura.length]);
+
+  function formatarNCMExibicao(codigo?: string) {
+    if (!codigo) return '';
+    const digits = String(codigo).replace(/\D/g, '').slice(0, 8);
+    if (digits.length <= 4) return digits;
+    if (digits.length <= 6) return digits.replace(/(\d{4})(\d{1,2})/, '$1.$2');
+    return digits.replace(/(\d{4})(\d{2})(\d{1,2})/, '$1.$2.$3');
+  }
+
+  function ordenarAtributos(lista: AtributoEstrutura[]): AtributoEstrutura[] {
+    const map = new Map(lista.map(a => [a.codigo, a]));
+    const resultado: AtributoEstrutura[] = [];
+    const visitados = new Set<string>();
+
+    function inserir(attr: AtributoEstrutura) {
+      if (visitados.has(attr.codigo)) return;
+      visitados.add(attr.codigo);
+      if (attr.subAtributos) {
+        attr.subAtributos = ordenarAtributos(attr.subAtributos);
+      }
+      resultado.push(attr);
+      for (const a of lista) {
+        if (a.parentCodigo === attr.codigo && map.get(attr.codigo)?.tipo !== 'COMPOSTO') {
+          inserir(a);
+        }
+      }
+    }
+
+    for (const attr of lista) {
+      if (!attr.parentCodigo || map.get(attr.parentCodigo)?.tipo === 'COMPOSTO') {
+        inserir(attr);
+      }
+    }
+
+    for (const attr of lista) if (!visitados.has(attr.codigo)) inserir(attr);
+
+    return resultado;
+  }
+
+  async function carregarEstrutura(ncmCodigo: string, modalidadeSelecionada: string, valoresIniciais?: Record<string, string | string[]>) {
+    if (ncmCodigo.length < 8) return;
+    setLoadingEstrutura(true);
+    try {
+      const response = await api.get(`/siscomex/atributos/ncm/${ncmCodigo}?modalidade=${modalidadeSelecionada}`);
+      if (!response.data.descricaoNcm) {
+        addToast('NCM não encontrada', 'error');
+        setEstruturaCarregada(false);
+        setNcmDescricao('');
+        setUnidadeMedida('');
+        setEstrutura([]);
+        setValores({});
+        return;
+      }
+
+      const dados: AtributoEstrutura[] = response.data.dados || [];
+      setNcmDescricao(response.data.descricaoNcm);
+      setUnidadeMedida(response.data.unidadeMedida || '');
+      const estruturaOrdenada = ordenarAtributos(dados);
+      setEstrutura(estruturaOrdenada);
+      setValores(valoresIniciais ? { ...valoresIniciais } : {});
+      setEstruturaCarregada(true);
+    } catch (error) {
+      console.error('Erro ao carregar atributos da NCM:', error);
+      addToast('Erro ao carregar atributos da NCM', 'error');
+      setEstruturaCarregada(false);
+      setEstrutura([]);
+      setValores({});
+    } finally {
+      setLoadingEstrutura(false);
+    }
+  }
+
+  async function carregarRegistro(registroId: string) {
+    try {
+      setLoading(true);
+      const resposta = await api.get<NcmValorPadraoDetalhe>(`/ncm-valores-padrao/${registroId}`);
+      const registro = resposta.data;
+      setNcm(registro.ncmCodigo);
+      const modalidadeRegistro = (registro.modalidade || 'IMPORTACAO') as 'IMPORTACAO' | 'EXPORTACAO';
+      setModalidade(modalidadeRegistro);
+      const valoresIniciais = (registro.valoresJson || {}) as Record<string, string | string[]>;
+      await carregarEstrutura(registro.ncmCodigo, modalidadeRegistro, valoresIniciais);
+      setLoading(false);
+    } catch (error) {
+      console.error('Erro ao carregar valores padrão:', error);
+      addToast('Erro ao carregar valores padrão', 'error');
+      setLoading(false);
+      router.push('/produtos/valores-padrao');
+    }
+  }
+
+  function handleValor(codigo: string, valor: string | string[]) {
+    setValores(prev => ({ ...prev, [codigo]: valor }));
+  }
+
+  function condicaoAtendida(attr: AtributoEstrutura): boolean {
+    const codigoCondicionante = attr.condicionanteCodigo || attr.parentCodigo;
+    if (!codigoCondicionante) return true;
+
+    const pai = mapaEstrutura.get(codigoCondicionante);
+    if (pai && !condicaoAtendida(pai)) return false;
+
+    const atual = valores[codigoCondicionante];
+    if (!isValorPreenchido(atual)) return false;
+
+    if (attr.condicao) {
+      return algumValorSatisfazCondicao(attr.condicao, atual);
+    }
+
+    if (!attr.descricaoCondicao) return true;
+    const regex = /valor\s*=\s*'?"?(\w+)"?'?/i;
+    const match = attr.descricaoCondicao.match(regex);
+    if (!match) return true;
+    const esperado = match[1];
+    return algumValorIgual(atual, esperado);
+  }
+
+  function renderCampo(attr: AtributoEstrutura): React.ReactNode {
+    if (!condicaoAtendida(attr)) return null;
+
+    const rawValue = valores[attr.codigo];
+    const value = rawValue !== undefined && !Array.isArray(rawValue) ? String(rawValue) : '';
+
+    switch (attr.tipo) {
+      case 'LISTA_ESTATICA':
+        if (attr.multivalorado) {
+          return (
+            <MultiSelect
+              key={attr.codigo}
+              label={attr.nome}
+              hint={attr.orientacaoPreenchimento}
+              required={attr.obrigatorio}
+              options={
+                attr.dominio?.map(d => ({
+                  value: d.codigo,
+                  label: `${d.codigo} - ${d.descricao}`
+                })) || []
+              }
+              placeholder="Selecione..."
+              values={normalizarValoresMultivalorados(rawValue)}
+              onChange={vals => handleValor(attr.codigo, vals)}
+            />
+          );
+        }
+        return (
+          <Select
+            key={attr.codigo}
+            label={attr.nome}
+            hint={attr.orientacaoPreenchimento}
+            required={attr.obrigatorio}
+            options={
+              attr.dominio?.map(d => ({
+                value: d.codigo,
+                label: `${d.codigo} - ${d.descricao}`
+              })) || []
+            }
+            placeholder="Selecione..."
+            value={value}
+            onChange={e => handleValor(attr.codigo, e.target.value)}
+          />
+        );
+      case 'BOOLEANO':
+        return (
+          <RadioGroup
+            key={attr.codigo}
+            label={attr.nome}
+            hint={attr.orientacaoPreenchimento}
+            required={attr.obrigatorio}
+            options={[
+              { value: 'true', label: 'Sim' },
+              { value: 'false', label: 'Não' }
+            ]}
+            value={value}
+            onChange={v => handleValor(attr.codigo, v)}
+          />
+        );
+      case 'NUMERO_INTEIRO':
+      case 'NUMERO_REAL':
+        return (
+          <Input
+            key={attr.codigo}
+            label={attr.nome}
+            hint={attr.orientacaoPreenchimento}
+            type="number"
+            required={attr.obrigatorio}
+            value={value}
+            onChange={e => handleValor(attr.codigo, e.target.value)}
+            step={attr.tipo === 'NUMERO_REAL' ? '0.01' : undefined}
+          />
+        );
+      case 'COMPOSTO':
+        return (
+          <div key={attr.codigo} className="col-span-3">
+            <p className="font-medium mb-2 text-sm">{attr.nome}</p>
+            <div className="grid grid-cols-3 gap-4 pl-4">
+              {attr.subAtributos?.map(sa => renderCampo(sa))}
+            </div>
+          </div>
+        );
+      default:
+        if (attr.tipo === 'TEXTO') {
+          const max = attr.validacoes?.tamanho_maximo ?? 0;
+          const pattern = attr.validacoes?.mascara;
+
+          if (pattern) {
+            let span = 'col-span-1';
+            if (max > 30 && max <= 60) span = 'col-span-2';
+            else if (max > 60) span = 'col-span-3';
+
+            return (
+              <MaskedInput
+                key={attr.codigo}
+                label={attr.nome}
+                hint={attr.orientacaoPreenchimento}
+                required={attr.obrigatorio}
+                value={value}
+                pattern={pattern}
+                onChange={(valorLimpo) => handleValor(attr.codigo, valorLimpo)}
+                className={span}
+              />
+            );
+          }
+
+          if (max >= 100) {
+            return (
+              <div key={attr.codigo} className="col-span-3 mb-4">
+                <label
+                  htmlFor={attr.codigo}
+                  className="block text-sm font-medium mb-1 text-gray-300"
+                >
+                  {attr.nome}
+                  {attr.obrigatorio && (
+                    <span className="text-red-400 ml-1">*</span>
+                  )}
+                  {attr.orientacaoPreenchimento && (
+                    <Hint text={attr.orientacaoPreenchimento} />
+                  )}
+                </label>
+                <textarea
+                  id={attr.codigo}
+                  rows={3}
+                  className="w-full px-2 py-1 text-sm bg-[#1e2126] border border-gray-700 text-white rounded-md focus:outline-none focus:ring focus:border-blue-500"
+                  value={value}
+                  onChange={e => handleValor(attr.codigo, e.target.value)}
+                />
+              </div>
+            );
+          }
+
+          let span = 'col-span-1';
+          if (max > 30 && max <= 60) span = 'col-span-2';
+          else if (max > 60) span = 'col-span-3';
+
+          return (
+            <Input
+              key={attr.codigo}
+              label={attr.nome}
+              hint={attr.orientacaoPreenchimento}
+              required={attr.obrigatorio}
+              value={value}
+              onChange={e => handleValor(attr.codigo, e.target.value)}
+              className={span}
+            />
+          );
+        }
+
+        return (
+          <Input
+            key={attr.codigo}
+            label={attr.nome}
+            hint={attr.orientacaoPreenchimento}
+            required={attr.obrigatorio}
+            value={value}
+            onChange={e => handleValor(attr.codigo, e.target.value)}
+          />
+        );
+    }
+  }
+
+  function handleNcmChange(valor: string) {
+    setNcm(valor);
+    if (valor.length < 4 || valor.length >= 8) {
+      setNcmSugestoes([]);
+      setMostrarSugestoesNcm(false);
+      setCarregandoSugestoesNcm(false);
+    }
+    if (valor.length === 8) {
+      carregarEstrutura(valor, modalidade);
+    } else {
+      setNcmDescricao('');
+      setUnidadeMedida('');
+      setEstruturaCarregada(false);
+      setEstrutura([]);
+      setValores({});
+    }
+  }
+
+  function selecionarSugestaoNcm(sugestao: { codigo: string; descricao: string | null }) {
+    setNcmDescricao(sugestao.descricao || '');
+    setMostrarSugestoesNcm(false);
+    setNcmSugestoes([]);
+    handleNcmChange(sugestao.codigo);
+  }
+
+  async function salvar() {
+    if (ncm.length !== 8) {
+      setErroFormulario('Informe uma NCM válida (8 dígitos).');
+      addToast('Informe uma NCM válida para salvar os valores padrão.', 'error');
+      return;
+    }
+
+    if (!estruturaCarregada) {
+      setErroFormulario('Carregue os atributos da NCM antes de salvar.');
+      addToast('Carregue os atributos da NCM antes de salvar.', 'error');
+      return;
+    }
+
+    try {
+      setErroFormulario(null);
+      setLoading(true);
+      const payload = {
+        ncmCodigo: ncm,
+        modalidade,
+        valoresAtributos: valores,
+        estruturaSnapshot: estrutura
+      };
+
+      if (isNew) {
+        await api.post('/ncm-valores-padrao', payload);
+        addToast('Valores padrão cadastrados com sucesso!', 'success');
+      } else if (typeof id === 'string') {
+        await api.put(`/ncm-valores-padrao/${id}`, payload);
+        addToast('Valores padrão atualizados com sucesso!', 'success');
+      }
+      router.push('/produtos/valores-padrao');
+    } catch (error: any) {
+      console.error('Erro ao salvar valores padrão:', error);
+      if (error.response?.data?.error) {
+        addToast(error.response.data.error, 'error');
+      } else {
+        addToast('Erro ao salvar valores padrão', 'error');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function voltar() {
+    router.push('/produtos/valores-padrao');
+  }
+
+  return (
+    <DashboardLayout title={isNew ? 'Novo Valor Padrão de NCM' : 'Editar Valor Padrão de NCM'}>
+      <Breadcrumb
+        items={[
+          { label: 'Início', href: '/' },
+          { label: 'Produtos', href: '/produtos' },
+          { label: 'Valores Padrão por NCM', href: '/produtos/valores-padrao' },
+          { label: isNew ? 'Novo' : 'Editar' }
+        ]}
+      />
+
+      <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-2">
+          <button onClick={voltar} className="text-gray-400 hover:text-white transition-colors">
+            <ArrowLeft size={20} />
+          </button>
+          <h1 className="text-2xl font-semibold text-white">
+            {isNew ? 'Cadastrar Valores Padrão' : 'Editar Valores Padrão'}
+          </h1>
+        </div>
+        <div className="flex items-center gap-3 self-end md:self-auto">
+          <Button type="button" variant="outline" onClick={voltar}>
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            variant="accent"
+            className="flex items-center gap-2"
+            onClick={salvar}
+            disabled={loading}
+          >
+            <Save size={16} />
+            Salvar
+          </Button>
+        </div>
+      </div>
+
+      <Card className="mb-6">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <MaskedInput
+            label="NCM"
+            mask="ncm"
+            value={ncm}
+            onChange={handleNcmChange}
+            className="mb-0"
+            required
+            disabled={loading}
+            onFocus={() => {
+              if (ncm.length >= 4 && ncm.length < 8 && ncmSugestoes.length > 0) {
+                setMostrarSugestoesNcm(true);
+              }
+            }}
+            onBlur={() => {
+              setTimeout(() => setMostrarSugestoesNcm(false), 100);
+            }}
+            autoComplete="off"
+          />
+          <Select
+            label="Modalidade"
+            options={[
+              { value: 'IMPORTACAO', label: 'Importação' },
+              { value: 'EXPORTACAO', label: 'Exportação' }
+            ]}
+            value={modalidade}
+            onChange={e => {
+              const novaModalidade = e.target.value as 'IMPORTACAO' | 'EXPORTACAO';
+              setModalidade(novaModalidade);
+              if (ncm.length === 8) {
+                carregarEstrutura(ncm, novaModalidade);
+              }
+            }}
+          />
+          <Input label="Descrição NCM" value={ncmDescricao} disabled className="md:col-span-2" />
+          <Input label="Unidade de Medida" value={unidadeMedida} disabled />
+        </div>
+
+        {(carregandoSugestoesNcm || mostrarSugestoesNcm) && ncm.length < 8 && (
+          <div className="relative">
+            <div className="absolute left-0 right-0 top-full z-20 mt-1 max-h-64 md:max-h-80 overflow-y-auto rounded-md border border-gray-700 bg-[#1e2126] shadow-lg">
+              {carregandoSugestoesNcm ? (
+                <div className="px-3 py-2 text-sm text-gray-400">Buscando sugestões...</div>
+              ) : ncmSugestoes.length === 0 ? (
+                <div className="px-3 py-2 text-sm text-gray-400">Nenhuma sugestão encontrada</div>
+              ) : (
+                ncmSugestoes.map(sugestao => (
+                  <button
+                    key={sugestao.codigo}
+                    type="button"
+                    className="flex w-full flex-col items-start px-3 py-2 text-left text-sm text-gray-100 hover:bg-gray-700"
+                    onMouseDown={event => event.preventDefault()}
+                    onClick={() => selecionarSugestaoNcm(sugestao)}
+                  >
+                    <span className="font-medium">{formatarNCMExibicao(sugestao.codigo)}</span>
+                    {sugestao.descricao && (
+                      <span className="text-xs text-gray-400">{sugestao.descricao}</span>
+                    )}
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+        )}
+      </Card>
+
+      {erroFormulario && (
+        <Card className="mb-6 border border-red-500/40 bg-red-500/10 text-sm text-red-300">
+          <p>{erroFormulario}</p>
+        </Card>
+      )}
+
+      {loading && !estruturaCarregada ? (
+        <Card>
+          <PageLoader message="Carregando dados..." />
+        </Card>
+      ) : (
+        <Card>
+          {loadingEstrutura ? (
+            <PageLoader message="Carregando atributos da NCM..." />
+          ) : !estruturaCarregada ? (
+            <div className="py-10 text-center text-gray-400">
+              Informe uma NCM válida para carregar os atributos.
+            </div>
+          ) : (
+            <div className="grid grid-cols-3 gap-4 text-sm">
+              {estrutura.map(attr => renderCampo(attr))}
+            </div>
+          )}
+        </Card>
+      )}
+    </DashboardLayout>
+  );
+}

--- a/frontend/pages/produtos/valores-padrao/index.tsx
+++ b/frontend/pages/produtos/valores-padrao/index.tsx
@@ -1,0 +1,218 @@
+// frontend/pages/produtos/valores-padrao/index.tsx
+import React, { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+import { Breadcrumb } from '@/components/ui/Breadcrumb';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { useToast } from '@/components/ui/ToastContext';
+import api from '@/lib/api';
+import { Pencil, Plus, Search, Trash2 } from 'lucide-react';
+
+interface NcmValorPadrao {
+  id: number;
+  ncmCodigo: string;
+  modalidade?: string | null;
+  criadoEm: string;
+  atualizadoEm: string;
+}
+
+function formatarNCM(ncm: string) {
+  const digits = ncm.replace(/\D/g, '').slice(0, 8);
+  if (digits.length <= 4) return digits;
+  if (digits.length <= 6) return digits.replace(/(\d{4})(\d{1,2})/, '$1.$2');
+  return digits.replace(/(\d{4})(\d{2})(\d{1,2})/, '$1.$2.$3');
+}
+
+function formatarData(dataIso: string) {
+  if (!dataIso) return '-';
+  const data = new Date(dataIso);
+  if (Number.isNaN(data.getTime())) return '-';
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(data);
+}
+
+export default function ValoresPadraoNcmListaPage() {
+  const [registros, setRegistros] = useState<NcmValorPadrao[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [erroCarregamento, setErroCarregamento] = useState(false);
+  const [filtro, setFiltro] = useState('');
+  const [registroParaExcluir, setRegistroParaExcluir] = useState<NcmValorPadrao | null>(null);
+  const { addToast } = useToast();
+  const router = useRouter();
+
+  useEffect(() => {
+    carregar();
+  }, []);
+
+  async function carregar() {
+    try {
+      setLoading(true);
+      setErroCarregamento(false);
+      const resposta = await api.get('/ncm-valores-padrao');
+      setRegistros(resposta.data || []);
+    } catch (error) {
+      console.error('Erro ao carregar valores padrão de NCM:', error);
+      setErroCarregamento(true);
+      addToast('Erro ao carregar valores padrão de NCM', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function remover() {
+    if (!registroParaExcluir) return;
+    try {
+      await api.delete(`/ncm-valores-padrao/${registroParaExcluir.id}`);
+      setRegistros(prev => prev.filter(item => item.id !== registroParaExcluir.id));
+      addToast('Valores padrão removidos com sucesso', 'success');
+    } catch (error) {
+      console.error('Erro ao remover valores padrão de NCM:', error);
+      addToast('Erro ao remover valores padrão de NCM', 'error');
+    } finally {
+      setRegistroParaExcluir(null);
+    }
+  }
+
+  const registrosFiltrados = useMemo(() => {
+    const termo = filtro.trim().toLowerCase();
+    if (!termo) return registros;
+    return registros.filter(item => {
+      const ncmMatch = formatarNCM(item.ncmCodigo).replace(/\./g, '').includes(termo.replace(/\D/g, ''));
+      const modalidadeMatch = (item.modalidade || '').toLowerCase().includes(termo);
+      return ncmMatch || modalidadeMatch;
+    });
+  }, [filtro, registros]);
+
+  return (
+    <DashboardLayout title="Valores Padrão por NCM">
+      <Breadcrumb
+        items={[
+          { label: 'Início', href: '/' },
+          { label: 'Produtos', href: '/produtos' },
+          { label: 'Valores Padrão por NCM' }
+        ]}
+      />
+
+      <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <h1 className="text-2xl font-semibold text-white">Valores Padrão por NCM</h1>
+        <Button
+          variant="accent"
+          className="flex items-center gap-2 self-end md:self-auto"
+          onClick={() => router.push('/produtos/valores-padrao/novo')}
+        >
+          <Plus size={16} />
+          Novo Grupo
+        </Button>
+      </div>
+
+      <Card className="mb-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+          <div className="relative md:col-span-2">
+            <label className="block text-sm font-medium mb-2 text-gray-300">Filtrar por NCM ou modalidade</label>
+            <div className="absolute left-0 top-1/2 -translate-y-1/2 pl-3 pointer-events-none">
+              <Search size={18} className="text-gray-400" />
+            </div>
+            <input
+              type="text"
+              className="pl-10 pr-4 py-2 w-full bg-[#1e2126] border border-gray-700 text-white rounded-lg focus:outline-none focus:ring focus:border-blue-500"
+              value={filtro}
+              onChange={event => setFiltro(event.target.value)}
+              placeholder="Digite a NCM ou modalidade"
+            />
+          </div>
+          <div className="text-sm text-gray-400">
+            Exibindo {registrosFiltrados.length} de {registros.length} grupos
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        {loading ? (
+          <div className="py-10 text-center text-gray-400">Carregando valores padrão...</div>
+        ) : erroCarregamento ? (
+          <div className="py-10 text-center text-gray-400">
+            Não foi possível carregar os valores padrão. <br />
+            <button className="text-blue-400 hover:underline" onClick={carregar}>
+              Tentar novamente
+            </button>
+          </div>
+        ) : registros.length === 0 ? (
+          <div className="py-10 text-center text-gray-400">
+            Nenhum valor padrão cadastrado.
+          </div>
+        ) : registrosFiltrados.length === 0 ? (
+          <div className="py-10 text-center text-gray-400">
+            Nenhum registro encontrado com os filtros aplicados.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm text-left">
+              <thead className="text-gray-400 bg-[#0f1419] uppercase text-xs">
+                <tr>
+                  <th className="w-20 px-4 py-3 text-center">Ações</th>
+                  <th className="px-4 py-3">NCM</th>
+                  <th className="px-4 py-3">Modalidade</th>
+                  <th className="px-4 py-3">Criado em</th>
+                  <th className="px-4 py-3">Atualizado em</th>
+                </tr>
+              </thead>
+              <tbody>
+                {registrosFiltrados.map(item => (
+                  <tr key={item.id} className="border-b border-gray-700 hover:bg-[#1a1f2b] transition-colors">
+                    <td className="px-4 py-3 text-center">
+                      <div className="flex items-center justify-center gap-2">
+                        <button
+                          className="p-1 text-gray-300 hover:text-blue-500 transition-colors"
+                          onClick={() => router.push(`/produtos/valores-padrao/${item.id}`)}
+                          title="Editar valores padrão"
+                        >
+                          <Pencil size={16} />
+                        </button>
+                        <button
+                          className="p-1 text-gray-300 hover:text-red-500 transition-colors"
+                          onClick={() => setRegistroParaExcluir(item)}
+                          title="Excluir valores padrão"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 font-medium text-white">{formatarNCM(item.ncmCodigo)}</td>
+                    <td className="px-4 py-3 text-gray-200">{item.modalidade ? item.modalidade : '-'}</td>
+                    <td className="px-4 py-3 text-gray-200">{formatarData(item.criadoEm)}</td>
+                    <td className="px-4 py-3 text-gray-200">{formatarData(item.atualizadoEm)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+
+      {registroParaExcluir && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <Card className="max-w-md w-full p-6">
+            <h3 className="text-xl font-semibold text-white mb-4">Confirmar exclusão</h3>
+            <p className="text-gray-300 mb-6">
+              Deseja remover os valores padrão da NCM {formatarNCM(registroParaExcluir.ncmCodigo)}?
+            </p>
+            <div className="flex justify-end gap-3">
+              <Button variant="outline" onClick={() => setRegistroParaExcluir(null)}>
+                Cancelar
+              </Button>
+              <Button variant="accent" onClick={remover}>
+                Remover
+              </Button>
+            </div>
+          </Card>
+        </div>
+      )}
+    </DashboardLayout>
+  );
+}

--- a/frontend/pages/produtos/valores-padrao/novo.tsx
+++ b/frontend/pages/produtos/valores-padrao/novo.tsx
@@ -1,0 +1,7 @@
+// frontend/pages/produtos/valores-padrao/novo.tsx
+import React from 'react';
+import ValoresPadraoNcmPage from './[id]';
+
+export default function NovoValoresPadraoNcmPage() {
+  return <ValoresPadraoNcmPage />;
+}

--- a/scripts_banco_catalogo_produtos.sql
+++ b/scripts_banco_catalogo_produtos.sql
@@ -313,7 +313,7 @@ DELIMITER ;
         id INT UNSIGNED NOT NULL AUTO_INCREMENT,
         super_user_id INT UNSIGNED NOT NULL,
         ncm_codigo VARCHAR(8) NOT NULL,
-        modalidade VARCHAR(20) NULL,
+        modalidade VARCHAR(10) NULL,
         valores_json JSON NOT NULL,
         estrutura_snapshot_json JSON NULL,
         criado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/scripts_banco_catalogo_produtos.sql
+++ b/scripts_banco_catalogo_produtos.sql
@@ -309,6 +309,23 @@ DELIMITER ;
         FOREIGN KEY (produto_id) REFERENCES produto(id)
     );
 
+    CREATE TABLE IF NOT EXISTS ncm_valores_padrao (
+        id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+        super_user_id INT UNSIGNED NOT NULL,
+        ncm_codigo VARCHAR(8) NOT NULL,
+        modalidade VARCHAR(20) NULL,
+        valores_json JSON NOT NULL,
+        estrutura_snapshot_json JSON NULL,
+        criado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        atualizado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        criado_por VARCHAR(255) NULL,
+        atualizado_por VARCHAR(255) NULL,
+        PRIMARY KEY (id),
+        UNIQUE KEY uk_superuser_ncm (super_user_id, ncm_codigo),
+        INDEX idx_ncm_valores_padrao_super_user (super_user_id),
+        CONSTRAINT fk_ncm_valores_padrao_super_user FOREIGN KEY (super_user_id) REFERENCES comex(idv32)
+    );
+
     CREATE TABLE IF NOT EXISTS codigo_interno_produto (
         id INT PRIMARY KEY AUTO_INCREMENT,
         produto_id INT NOT NULL,

--- a/scripts_banco_catalogo_produtos.sql
+++ b/scripts_banco_catalogo_produtos.sql
@@ -322,8 +322,8 @@ DELIMITER ;
         atualizado_por VARCHAR(255) NULL,
         PRIMARY KEY (id),
         UNIQUE KEY uk_superuser_ncm (super_user_id, ncm_codigo),
-        INDEX idx_ncm_valores_padrao_super_user (super_user_id),
-        CONSTRAINT fk_ncm_valores_padrao_super_user FOREIGN KEY (super_user_id) REFERENCES comex(idv32)
+        -- Integridade com o superusuário mantida via aplicação, pois a tabela comex está em outro schema
+        INDEX idx_ncm_valores_padrao_super_user (super_user_id)
     );
 
     CREATE TABLE IF NOT EXISTS codigo_interno_produto (

--- a/scripts_banco_catalogo_produtos.sql
+++ b/scripts_banco_catalogo_produtos.sql
@@ -321,7 +321,7 @@ DELIMITER ;
         criado_por VARCHAR(255) NULL,
         atualizado_por VARCHAR(255) NULL,
         PRIMARY KEY (id),
-        UNIQUE KEY uk_superuser_ncm (super_user_id, ncm_codigo),
+        UNIQUE KEY uk_superuser_ncm_modalidade (super_user_id, ncm_codigo, modalidade),
         -- Integridade com o superusuário mantida via aplicação, pois a tabela comex está em outro schema
         INDEX idx_ncm_valores_padrao_super_user (super_user_id)
     );


### PR DESCRIPTION
## Resumo
- adiciona tabela e API para gerenciar valores padrão de atributos por NCM
- cria telas de listagem e edição de valores padrão replicando o comportamento dinâmico dos atributos
- aplica valores padrão automaticamente ao cadastrar novo produto quando houver template disponível

## Testes
- npm run build (backend)
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68ddffa3086c8330b2b575015c55f3d9