### PR TITLE
feat: inclui python na imagem do backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,10 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 
+# Garante Python disponível para scripts que dependem do binário `python`
+RUN apk add --no-cache python3 \
+  && ln -sf python3 /usr/bin/python
+
 # 1) Copia manifestos e schema para gerar o Prisma Client
 COPY package.json package-lock.json ./
 COPY prisma ./prisma
@@ -18,6 +22,10 @@ RUN npm run build
 FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+
+# Disponibiliza Python também na imagem final de execução
+RUN apk add --no-cache python3 \
+  && ln -sf python3 /usr/bin/python
 
 # 1) Copia apenas o código compilado e as deps de produção
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
## Resumo
- instala o Python 3 nas fases de build e execução da imagem Docker do backend para permitir scripts que dependem do binário `python`

## Testes
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deb393c9588330b9c76e31722a7c65