### PR TITLE
Ajusta filtros e permite remoção de mensagens

### DIFF
--- a/backend/src/controllers/mensagem.controller.ts
+++ b/backend/src/controllers/mensagem.controller.ts
@@ -153,3 +153,27 @@ export function listarCategorias(_: Request, res: Response) {
   const categorias = mensagemService.listarCategorias();
   return res.json({ categorias });
 }
+
+export async function removerMensagem(req: Request, res: Response) {
+  try {
+    const superUserId = req.user?.superUserId;
+    if (!superUserId) {
+      return res.status(401).json({ error: 'Usuário não autenticado' });
+    }
+
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) {
+      return res.status(400).json({ error: 'Identificador inválido' });
+    }
+
+    const removida = await mensagemService.remover(superUserId, id);
+    if (!removida) {
+      return res.status(404).json({ error: 'Mensagem não encontrada' });
+    }
+
+    return res.status(204).send();
+  } catch (error) {
+    logger.error('Erro ao remover mensagem', error);
+    return res.status(500).json({ error: 'Erro ao remover mensagem' });
+  }
+}

--- a/backend/src/routes/mensagem.routes.ts
+++ b/backend/src/routes/mensagem.routes.ts
@@ -8,6 +8,7 @@ import {
   resumoNaoLidas,
   contarNaoLidas,
   listarCategorias,
+  removerMensagem,
 } from '../controllers/mensagem.controller';
 
 const router = Router();
@@ -20,5 +21,6 @@ router.get('/contagem-nao-lidas', contarNaoLidas);
 router.get('/', listarMensagens);
 router.get('/:id', obterMensagem);
 router.patch('/:id/lida', marcarMensagemComoLida);
+router.delete('/:id', removerMensagem);
 
 export default router;

--- a/backend/src/services/mensagem.service.ts
+++ b/backend/src/services/mensagem.service.ts
@@ -123,4 +123,21 @@ export class MensagemService {
   listarCategorias(): MensagemCategoria[] {
     return Object.values(MensagemCategoria);
   }
+
+  async remover(superUserId: number, id: number): Promise<boolean> {
+    const mensagem = await catalogoPrisma.mensagem.findFirst({
+      where: { id, superUserId },
+      select: { id: true },
+    });
+
+    if (!mensagem) {
+      return false;
+    }
+
+    await catalogoPrisma.mensagem.delete({
+      where: { id: mensagem.id },
+    });
+
+    return true;
+  }
 }

--- a/frontend/contexts/MessagesContext.tsx
+++ b/frontend/contexts/MessagesContext.tsx
@@ -38,6 +38,7 @@ interface MessagesContextValue {
   getMessage: (id: number) => Promise<Mensagem>;
   markAsRead: (id: number) => Promise<Mensagem | null>;
   listarCategorias: () => Promise<MensagemCategoria[]>;
+  removerMensagem: (id: number) => Promise<boolean>;
 }
 
 const MessagesContext = createContext<MessagesContextValue | undefined>(undefined);
@@ -128,6 +129,20 @@ export function MessagesProvider({ children }: { children: ReactNode }) {
     return data.categorias;
   }, []);
 
+  const removerMensagem = useCallback(
+    async (id: number) => {
+      try {
+        await api.delete(`/mensagens/${id}`);
+        await refreshUnread();
+        return true;
+      } catch (error) {
+        console.error('Erro ao remover mensagem:', error);
+        throw error;
+      }
+    },
+    [refreshUnread],
+  );
+
   useEffect(() => {
     if (!token) {
       stopPolling();
@@ -173,6 +188,7 @@ export function MessagesProvider({ children }: { children: ReactNode }) {
     getMessage,
     markAsRead,
     listarCategorias,
+    removerMensagem,
   }), [
     unreadMessages,
     unreadCount,
@@ -182,6 +198,7 @@ export function MessagesProvider({ children }: { children: ReactNode }) {
     getMessage,
     markAsRead,
     listarCategorias,
+    removerMensagem,
   ]);
 
   return (


### PR DESCRIPTION
## Resumo
- reposiciona o seletor de categorias ao lado dos filtros de status para liberar espaço na lista de mensagens
- adiciona ação de exclusão com ícone de lixeira e atualização automática da seleção no frontend
- cria endpoint e serviço de remoção de mensagens no backend e integra o contexto do frontend

## Testes
- CI=1 npm run build:all

------
https://chatgpt.com/codex/tasks/task_e_68ddfbadec7c8330b30710c472bb48c8