### PR TITLE
Adiciona número interno para operadores estrangeiros

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -187,6 +187,7 @@ model OperadorEstrangeiro {
   nome                String   @map("nome")
   email               String?  @map("email")
   codigoInterno       String?  @map("codigo_interno")
+  numero              Int      @unique @map("numero")
 
   // Endereço
   codigoPostal        String?  @map("codigo_postal")

--- a/backend/src/services/__tests__/operador-estrangeiro.service.test.ts
+++ b/backend/src/services/__tests__/operador-estrangeiro.service.test.ts
@@ -41,7 +41,7 @@ describe('OperadorEstrangeiroService - superUserId', () => {
       superUserId: 1
     })
     expect(catalogoPrisma.operadorEstrangeiro.create).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ catalogoId: 1 }) })
+      expect.objectContaining({ data: expect.objectContaining({ catalogoId: 1, numero: 0 }) })
     )
   })
 

--- a/backend/src/services/catalogo.service.ts
+++ b/backend/src/services/catalogo.service.ts
@@ -344,6 +344,7 @@ async clonar(id: number, nome: string, cpf_cnpj: string, superUserId: number) {
           nome: op.nome,
           email: op.email,
           codigoInterno: op.codigoInterno,
+          numero: 0,
           codigoPostal: op.codigoPostal,
           logradouro: op.logradouro,
           cidade: op.cidade,

--- a/backend/src/services/operador-estrangeiro.service.ts
+++ b/backend/src/services/operador-estrangeiro.service.ts
@@ -107,6 +107,7 @@ export class OperadorEstrangeiroService {
           nome: data.nome,
           email: data.email,
           codigoInterno: data.codigoInterno,
+          numero: 0,
           codigoPostal: data.codigoPostal,
           logradouro: data.logradouro,
           cidade: data.cidade,

--- a/docs/OPERADOR_ESTRANGEIRO.md
+++ b/docs/OPERADOR_ESTRANGEIRO.md
@@ -36,6 +36,7 @@ Cada operador está associado a um catálogo específico (`catalogo_id`). O supe
 - **nome**: Razão social do operador estrangeiro
 - **email**: Email de contato
 - **codigo_interno**: Código interno da empresa importadora
+- **numero**: Identificador interno aleatório gerado pelo sistema
 - **logradouro**: Endereço completo
 - **cidade**: Cidade do operador
 - **subdivisao_codigo**: Estado/província (referência para `subdivisao`)

--- a/docs/sql/2025-04-18_operador_estrangeiro_numero.sql
+++ b/docs/sql/2025-04-18_operador_estrangeiro_numero.sql
@@ -1,0 +1,45 @@
+-- Atualização: adiciona número interno único aos operadores estrangeiros
+-- Justificativa: padronizar identificação interna, alinhando com produtos e catálogos.
+
+ALTER TABLE operador_estrangeiro
+    ADD COLUMN numero INT UNSIGNED NOT NULL AFTER codigo_interno;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_operador_estrangeiro_numero ON operador_estrangeiro (numero);
+
+DROP FUNCTION IF EXISTS generate_unique_random_operador_numero;
+DELIMITER $$
+CREATE FUNCTION generate_unique_random_operador_numero()
+RETURNS INT UNSIGNED
+BEGIN
+    DECLARE random_num INT UNSIGNED;
+    DECLARE is_unique BOOLEAN DEFAULT FALSE;
+    DECLARE max_attempts INT DEFAULT 100;
+    DECLARE attempt_count INT DEFAULT 0;
+
+    WHILE NOT is_unique AND attempt_count < max_attempts DO
+        SET random_num = FLOOR(100000 + RAND() * 900000);
+        IF NOT EXISTS (SELECT 1 FROM operador_estrangeiro WHERE numero = random_num) THEN
+            SET is_unique = TRUE;
+        END IF;
+        SET attempt_count = attempt_count + 1;
+    END WHILE;
+
+    IF NOT is_unique THEN
+        SELECT IFNULL(MAX(numero), 100000) + 1 INTO random_num FROM operador_estrangeiro;
+    END IF;
+
+    RETURN random_num;
+END$$
+DELIMITER ;
+
+DROP TRIGGER IF EXISTS before_operador_estrangeiro_insert;
+DELIMITER $$
+CREATE TRIGGER before_operador_estrangeiro_insert
+BEFORE INSERT ON operador_estrangeiro
+FOR EACH ROW
+BEGIN
+    IF NEW.numero IS NULL OR NEW.numero = 0 THEN
+        SET NEW.numero = generate_unique_random_operador_numero();
+    END IF;
+END$$
+DELIMITER ;


### PR DESCRIPTION
## Resumo
- adiciona coluna de número interno e gatilho de geração automática para operadores estrangeiros
- ajusta Prisma, serviços e testes para considerar o novo identificador randômico
- documenta a mudança e publica script incremental em docs/sql

## Testes
- npm run build:all

------
https://chatgpt.com/codex/tasks/task_e_68e3a0187a708330a8f868367f79def1