### PR TITLE
Atualiza rotina de importação de produtos

### DIFF
--- a/backend/src/services/produto-importacao.service.ts
+++ b/backend/src/services/produto-importacao.service.ts
@@ -236,8 +236,7 @@ export class ProdutoImportacaoService {
                 const unicos = Array.from(new Set(partesFabricante));
                 operadoresEstrangeiros = unicos.map<OperadorEstrangeiroProdutoInput>(codigo => ({
                   paisCodigo: codigo,
-                  conhecido: false,
-                  operadorEstrangeiroId: null
+                  conhecido: false
                 }));
               }
             }

--- a/frontend/pages/automacao/importar-produto/nova.tsx
+++ b/frontend/pages/automacao/importar-produto/nova.tsx
@@ -294,9 +294,28 @@ export default function NovaImportacaoPage() {
               A planilha deve conter os seguintes campos na primeira linha (cabeçalho):
             </p>
             <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-gray-300">
-              <li><strong>Coluna A – NCM:</strong> código numérico de 8 dígitos, sem formatação.</li>
-              <li><strong>Coluna B – Denominação:</strong> nome do produto. Será replicado no campo descrição.</li>
-              <li><strong>Coluna C – Código interno / Partnumber:</strong> SKUs separados por vírgula (somente números).</li>
+              <li>
+                <strong>Coluna A – Código Interno:</strong> informe um ou mais códigos internos separados por vírgula. São
+                aceitos apenas letras e números, sem espaços.
+              </li>
+              <li>
+                <strong>Coluna B – Descrição Curta Produto:</strong> nome curto do produto. Campo obrigatório.
+              </li>
+              <li>
+                <strong>Coluna C – Descrição Longa Produto:</strong> detalhamento completo do item. Caso esteja vazio, será
+                utilizado o valor da descrição curta.
+              </li>
+              <li>
+                <strong>Coluna D – NCM:</strong> código numérico de 8 dígitos, sem formatação.
+              </li>
+              <li>
+                <strong>Coluna E – Fabricante:</strong> indique as siglas de países (duas letras) correspondentes aos fabricantes
+                separados por vírgula.
+              </li>
+              <li>
+                <strong>Coluna F – Operador Estrangeiro:</strong> informe os números dos operadores estrangeiros já cadastrados na
+                plataforma, separados por vírgula.
+              </li>
             </ul>
             <p className="mt-3 text-xs text-gray-400">
               Dicas: deixe linhas vazias no final da planilha em branco, garanta que a primeira linha contenha o cabeçalho indicado e salve o arquivo no formato .xlsx.


### PR DESCRIPTION
## Resumo
- Ajusta o processamento da planilha de importação para refletir a nova ordem de colunas e incluir fabricante e operadores estrangeiros com validações completas.
- Permite códigos internos alfanuméricos, usa descrição longa ao criar o produto e vincula operadores conhecidos e não conhecidos conforme informado na planilha.
- Atualiza as instruções da interface e amplia os testes automatizados para cobrir os novos cenários de validação.

## Testes
- npm test *(falha: exige variável de ambiente DATABASE_URL para o Prisma durante o setup de testes)*
- npm build *(falha: comando não disponível no package.json da raiz)*

------
https://chatgpt.com/codex/tasks/task_e_68e57147fc048330b783a5a4577235ca