### PR TITLE
Registrar histórico de versões de produto (API, serviço, UI e migração)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -229,6 +229,7 @@ model ProdutoTransmissao {
   catalogo  Catalogo  @relation(fields: [catalogoId], references: [id], onDelete: Cascade)
   asyncJob  AsyncJob? @relation(fields: [asyncJobId], references: [id])
   itens     ProdutoTransmissaoItem[]
+  historicoVersoes ProdutoHistoricoVersao[]
 
   @@index([catalogoId], map: "idx_transmissao_catalogo")
   @@index([superUserId], map: "idx_transmissao_superuser")
@@ -485,11 +486,34 @@ model Produto {
   operadoresEstrangeiros   OperadorEstrangeiroProduto[]
   importacaoItens          ImportacaoProdutoItem[] @relation("ProdutoImportacaoItens")
   transmissoes             ProdutoTransmissaoItem[]
+  historicoVersoes         ProdutoHistoricoVersao[]
 
   @@index([ncmCodigo], name: "idx_ncm")
   @@index([catalogoId], name: "idx_catalogo")
   @@unique([codigo, versao], name: "uk_codigo_versao")
   @@map("produto")
+}
+
+model ProdutoHistoricoVersao {
+  id             Int      @id @default(autoincrement()) @map("id")
+  produtoId      Int      @map("produto_id")
+  versaoSiscomex Int      @map("versao_siscomex")
+  tipoEvento     String   @map("tipo_evento")
+  resumo         String?  @map("resumo") @db.Text
+  deltaJson      Json?    @map("delta_json")
+  snapshotJson   Json?    @map("snapshot_json")
+  isCheckpoint   Boolean  @default(false) @map("is_checkpoint")
+  transmissaoId  Int?     @map("transmissao_id")
+  criadoEm       DateTime @default(now()) @map("criado_em")
+
+  produto      Produto             @relation(fields: [produtoId], references: [id], onDelete: Cascade)
+  transmissao  ProdutoTransmissao? @relation(fields: [transmissaoId], references: [id], onDelete: SetNull)
+
+  @@index([produtoId, versaoSiscomex], map: "idx_hist_produto_versao")
+  @@index([produtoId, criadoEm], map: "idx_hist_produto_data")
+  @@index([transmissaoId], map: "idx_hist_transmissao")
+  @@unique([produtoId, versaoSiscomex], name: "uk_hist_produto_versao")
+  @@map("produto_historico_versao")
 }
 
 model AtributoVersao {

--- a/backend/src/controllers/produto.controller.ts
+++ b/backend/src/controllers/produto.controller.ts
@@ -89,6 +89,20 @@ export async function obterProduto(req: Request, res: Response) {
   }
 }
 
+export async function obterHistoricoProduto(req: Request, res: Response) {
+  try {
+    const id = Number(req.params.id);
+    const historico = await produtoService.listarHistorico(id, req.user!.superUserId);
+    res.json(historico);
+  } catch (error: any) {
+    if (error.message?.includes('não encontrado')) {
+      return res.status(404).json({ error: error.message });
+    }
+    logger.error('Erro ao carregar histórico do produto:', error);
+    res.status(500).json({ error: error.message });
+  }
+}
+
 export async function criarProduto(req: Request, res: Response) {
   try {
     const produto = await produtoService.criar(

--- a/backend/src/routes/produto.routes.ts
+++ b/backend/src/routes/produto.routes.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import {
   listarProdutos,
   obterProduto,
+  obterHistoricoProduto,
   criarProduto,
   atualizarProduto,
   removerProduto,
@@ -47,6 +48,7 @@ router.get('/pendencias/ajuste-estrutura', contarPendenciasAjusteEstrutura);
 router.get('/pendencias/ajuste-estrutura/detalhes', listarPendenciasAjusteEstruturaDetalhadas);
 router.post('/ajuste-estrutura/ajustar-catalogo', ajustarEstruturaCatalogo);
 router.get('/:id', obterProduto);
+router.get('/:id/historico', obterHistoricoProduto);
 router.post('/', validate(createProdutoSchema), criarProduto);
 router.put('/:id', validate(updateProdutoSchema), atualizarProduto);
 router.post('/exportacoes', validate(exportarProdutosSchema), solicitarExportacaoProdutos);

--- a/backend/src/services/produto-transmissao.service.ts
+++ b/backend/src/services/produto-transmissao.service.ts
@@ -453,6 +453,7 @@ export class ProdutoTransmissaoService {
           versao: versaoNumero,
           situacao: situacaoProduto,
           atualizarCodigo: !deveAtualizarVersao,
+          transmissaoId: transmissao.id,
         });
 
         sucessos.push({

--- a/backend/src/services/produto.service.ts
+++ b/backend/src/services/produto.service.ts
@@ -10,6 +10,12 @@ import {
 import { ValidationError } from '../types/validation-error';
 import { ProdutoResumoService } from './produto-resumo.service';
 import { ResultadoVerificacao } from '../jobs/handlers/verificacao-atributos-ncm.handler';
+import {
+  DeltaHistoricoProduto,
+  gerarDeltaHistoricoProduto,
+  gerarResumoDelta,
+  normalizarProdutoParaHistorico
+} from '../utils/produto-historico-diff';
 
 export interface CreateProdutoDTO {
   codigo?: string;
@@ -120,6 +126,15 @@ export interface PendenciaAjusteEstruturaDTO {
   modalidade: string;
   diferencas?: ResultadoVerificacao['diferencas'];
   catalogos: PendenciaAjusteEstruturaCatalogoDTO[];
+}
+
+export interface ProdutoHistoricoVersaoDTO {
+  id: number;
+  versaoSiscomex: number;
+  tipoEvento: string;
+  resumo: string | null;
+  delta: DeltaHistoricoProduto | null;
+  criadoEm: Date;
 }
 
 export class ProdutoService {
@@ -380,6 +395,129 @@ export class ProdutoService {
       catalogoCpfCnpj: p.catalogo?.cpf_cnpj,
       catalogoAmbiente: p.catalogo?.ambiente
     };
+  }
+
+  async listarHistorico(id: number, superUserId: number): Promise<ProdutoHistoricoVersaoDTO[]> {
+    const produto = await catalogoPrisma.produto.findFirst({
+      where: { id, catalogo: { superUserId } },
+      select: { id: true }
+    });
+
+    if (!produto) {
+      throw new Error(`Produto ID ${id} não encontrado`);
+    }
+
+    const historico = await catalogoPrisma.produtoHistoricoVersao.findMany({
+      where: { produtoId: id },
+      orderBy: [{ versaoSiscomex: 'desc' }, { criadoEm: 'desc' }]
+    });
+
+    return historico.map(item => ({
+      id: item.id,
+      versaoSiscomex: item.versaoSiscomex,
+      tipoEvento: item.tipoEvento,
+      resumo: item.resumo,
+      delta: (item.deltaJson as DeltaHistoricoProduto | null) ?? null,
+      criadoEm: item.criadoEm
+    }));
+  }
+
+  async obterSnapshotParaHistorico(
+    produtoId: number,
+    superUserId: number,
+    tx?: Prisma.TransactionClient
+  ): Promise<Record<string, unknown>> {
+    const prisma = tx ?? catalogoPrisma;
+    const produto = await prisma.produto.findFirst({
+      where: { id: produtoId, catalogo: { superUserId } },
+      include: {
+        atributos: {
+          include: {
+            atributo: { select: { codigo: true, multivalorado: true } },
+            valores: { orderBy: { ordem: 'asc' } }
+          }
+        },
+        codigosInternos: { select: { codigo: true } },
+        operadoresEstrangeiros: {
+          select: {
+            paisCodigo: true,
+            conhecido: true,
+            operadorEstrangeiroId: true
+          }
+        }
+      }
+    });
+
+    if (!produto) {
+      throw new Error(`Produto ID ${produtoId} não encontrado`);
+    }
+
+    const valoresAtributos = this.montarValoresDosAtributos(produto.atributos);
+
+    return normalizarProdutoParaHistorico({
+      codigo: produto.codigo,
+      versao: produto.versao,
+      ncmCodigo: produto.ncmCodigo,
+      modalidade: produto.modalidade,
+      denominacao: produto.denominacao,
+      descricao: produto.descricao,
+      situacao: produto.situacao,
+      codigosInternos: produto.codigosInternos.map(item => item.codigo),
+      operadoresEstrangeiros: produto.operadoresEstrangeiros,
+      valoresAtributos
+    });
+  }
+
+  async registrarHistoricoVersao(params: {
+    produtoId: number;
+    superUserId: number;
+    versaoSiscomex: number;
+    transmissaoId?: number;
+    snapshotAnterior?: Record<string, unknown>;
+    tx?: Prisma.TransactionClient;
+  }) {
+    const prisma = params.tx ?? catalogoPrisma;
+    const snapshotAtual = await this.obterSnapshotParaHistorico(
+      params.produtoId,
+      params.superUserId,
+      params.tx
+    );
+    const snapshotAnterior = params.snapshotAnterior ?? null;
+
+    const delta = gerarDeltaHistoricoProduto(snapshotAnterior, snapshotAtual);
+    const resumo = gerarResumoDelta(delta, params.versaoSiscomex);
+    const isCheckpoint = params.versaoSiscomex === 1 || params.versaoSiscomex % 10 === 0;
+    const deltaJson = delta as unknown as Prisma.InputJsonValue;
+    const snapshotJson = isCheckpoint
+      ? (snapshotAtual as unknown as Prisma.InputJsonValue)
+      : Prisma.JsonNull;
+
+    await prisma.produtoHistoricoVersao.upsert({
+      where: {
+        uk_hist_produto_versao: {
+          produtoId: params.produtoId,
+          versaoSiscomex: params.versaoSiscomex
+        }
+      },
+      update: {
+        tipoEvento: params.versaoSiscomex === 1 ? 'CRIACAO' : 'ATUALIZACAO',
+        resumo,
+        deltaJson,
+        snapshotJson,
+        isCheckpoint,
+        transmissaoId: params.transmissaoId ?? null
+      },
+      create: {
+        produtoId: params.produtoId,
+        versaoSiscomex: params.versaoSiscomex,
+        tipoEvento: params.versaoSiscomex === 1 ? 'CRIACAO' : 'ATUALIZACAO',
+        resumo,
+        deltaJson,
+        snapshotJson,
+        isCheckpoint,
+        transmissaoId: params.transmissaoId ?? null
+      }
+    });
   }
 
   async criar(
@@ -656,7 +794,13 @@ export class ProdutoService {
   async marcarComoTransmitido(
     id: number,
     superUserId: number,
-    dados: { codigo?: string | number | null; versao: number | string; situacao?: 'RASCUNHO' | 'ATIVADO' | 'DESATIVADO'; atualizarCodigo?: boolean }
+    dados: {
+      codigo?: string | number | null;
+      versao: number | string;
+      situacao?: 'RASCUNHO' | 'ATIVADO' | 'DESATIVADO';
+      atualizarCodigo?: boolean;
+      transmissaoId?: number;
+    }
   ) {
     const versaoNumero = typeof dados.versao === 'string' ? Number(dados.versao) : dados.versao;
 
@@ -680,16 +824,30 @@ export class ProdutoService {
       dadosAtualizacao.codigo = codigoNormalizado;
     }
 
-    const atualizado = await catalogoPrisma.produto.updateMany({
-      where: { id, catalogo: { superUserId } },
-      data: dadosAtualizacao
+    await catalogoPrisma.$transaction(async tx => {
+      const snapshotAnterior = await this.obterSnapshotParaHistorico(id, superUserId, tx);
+
+      const atualizado = await tx.produto.updateMany({
+        where: { id, catalogo: { superUserId } },
+        data: dadosAtualizacao
+      });
+
+      if (atualizado.count === 0) {
+        throw new Error('Produto não encontrado ou não pertence ao superusuário');
+      }
+
+      await this.registrarHistoricoVersao({
+        produtoId: id,
+        superUserId,
+        versaoSiscomex: versaoNumero,
+        transmissaoId: dados.transmissaoId,
+        snapshotAnterior,
+        tx
+      });
+
+      await this.produtoResumoService.recalcularResumoProduto(id, tx);
     });
 
-    if (atualizado.count === 0) {
-      throw new Error('Produto não encontrado ou não pertence ao superusuário');
-    }
-
-    await this.produtoResumoService.recalcularResumoProduto(id);
     return this.buscarPorId(id, superUserId);
   }
 

--- a/backend/src/utils/__tests__/produto-historico-diff.test.ts
+++ b/backend/src/utils/__tests__/produto-historico-diff.test.ts
@@ -27,4 +27,23 @@ describe('produto-historico-diff', () => {
     const delta = gerarDeltaHistoricoProduto(null, { denominacao: 'Produto novo' });
     expect(gerarResumoDelta(delta, 1)).toBe('Produto criado no SISCOMEX.');
   });
+
+  it('deve preservar mudanças quando snapshot anterior é nulo', () => {
+    const delta = gerarDeltaHistoricoProduto(null, {
+      denominacao: 'Produto novo',
+      descricao: 'Descrição nova'
+    });
+
+    expect(delta.changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: 'denominacao', op: 'add', after: 'Produto novo' }),
+        expect.objectContaining({ path: 'descricao', op: 'add', after: 'Descrição nova' })
+      ])
+    );
+  });
+
+  it('deve priorizar resumo de criação mesmo sem mudanças na versão 1', () => {
+    const deltaSemMudancas = gerarDeltaHistoricoProduto({ codigo: '1' }, { codigo: '1' });
+    expect(gerarResumoDelta(deltaSemMudancas, 1)).toBe('Produto criado no SISCOMEX.');
+  });
 });

--- a/backend/src/utils/__tests__/produto-historico-diff.test.ts
+++ b/backend/src/utils/__tests__/produto-historico-diff.test.ts
@@ -1,0 +1,30 @@
+import {
+  gerarDeltaHistoricoProduto,
+  gerarResumoDelta,
+  normalizarProdutoParaHistorico,
+} from '../produto-historico-diff';
+
+describe('produto-historico-diff', () => {
+  it('deve ordenar arrays escalares na normalização', () => {
+    const normalizado = normalizarProdutoParaHistorico({ codigosInternos: ['B', 'A'] });
+    expect(normalizado).toEqual({ codigosInternos: ['A', 'B'] });
+  });
+
+  it('deve gerar alteração de campo simples', () => {
+    const delta = gerarDeltaHistoricoProduto(
+      { denominacao: 'Produto antigo' },
+      { denominacao: 'Produto novo' }
+    );
+
+    expect(delta.changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: 'denominacao', op: 'replace', before: 'Produto antigo', after: 'Produto novo' })
+      ])
+    );
+  });
+
+  it('deve gerar resumo de criação na versão 1', () => {
+    const delta = gerarDeltaHistoricoProduto(null, { denominacao: 'Produto novo' });
+    expect(gerarResumoDelta(delta, 1)).toBe('Produto criado no SISCOMEX.');
+  });
+});

--- a/backend/src/utils/produto-historico-diff.ts
+++ b/backend/src/utils/produto-historico-diff.ts
@@ -75,6 +75,22 @@ function diffRecursivo(
     return;
   }
 
+  if (!pathAtual) {
+    if ((anterior === null || anterior === undefined) && isObject(atual)) {
+      for (const key of Object.keys(atual).sort()) {
+        diffRecursivo(undefined, atual[key], key, changes);
+      }
+      return;
+    }
+
+    if ((atual === null || atual === undefined) && isObject(anterior)) {
+      for (const key of Object.keys(anterior).sort()) {
+        diffRecursivo(anterior[key], undefined, key, changes);
+      }
+      return;
+    }
+  }
+
   if (Array.isArray(anterior) || Array.isArray(atual)) {
     changes.push({
       path: pathAtual,
@@ -115,12 +131,12 @@ export function gerarDeltaHistoricoProduto(anterior: unknown, atual: unknown): D
 }
 
 export function gerarResumoDelta(delta: DeltaHistoricoProduto, versaoSiscomex: number) {
-  if (!delta.changes.length) {
-    return `Versão ${versaoSiscomex} sem alterações de conteúdo.`;
-  }
-
   if (versaoSiscomex <= 1) {
     return 'Produto criado no SISCOMEX.';
+  }
+
+  if (!delta.changes.length) {
+    return `Versão ${versaoSiscomex} sem alterações de conteúdo.`;
   }
 
   return `${delta.changes.length} alteração(ões) na versão ${versaoSiscomex}.`;

--- a/backend/src/utils/produto-historico-diff.ts
+++ b/backend/src/utils/produto-historico-diff.ts
@@ -1,0 +1,127 @@
+export type OperacaoDelta = 'add' | 'remove' | 'replace';
+
+export interface MudancaDelta {
+  path: string;
+  op: OperacaoDelta;
+  before?: unknown;
+  after?: unknown;
+  label?: string;
+}
+
+export interface DeltaHistoricoProduto {
+  schemaVersion: number;
+  changes: MudancaDelta[];
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizarEscalar(value: unknown): unknown {
+  if (value === '') return null;
+  if (value instanceof Date) return value.toISOString();
+  return value;
+}
+
+export function normalizarProdutoParaHistorico<T>(input: T): T {
+  const normalizar = (value: unknown): unknown => {
+    if (Array.isArray(value)) {
+      const items = value.map(item => normalizar(item));
+      const todosEscalares = items.every(item => !isObject(item) && !Array.isArray(item));
+      if (todosEscalares) {
+        return [...items].sort((a, b) => String(a).localeCompare(String(b)));
+      }
+      return items;
+    }
+
+    if (isObject(value)) {
+      const keys = Object.keys(value).sort();
+      return keys.reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = normalizar(value[key]);
+        return acc;
+      }, {});
+    }
+
+    return normalizarEscalar(value);
+  };
+
+  return normalizar(input) as T;
+}
+
+function labelPorPath(path: string) {
+  const labels: Record<string, string> = {
+    codigo: 'Código',
+    versao: 'Versão',
+    denominacao: 'Denominação',
+    descricao: 'Descrição',
+    modalidade: 'Modalidade',
+    ncmCodigo: 'NCM',
+    codigosInternos: 'Códigos internos',
+    operadoresEstrangeiros: 'Operadores estrangeiros',
+    valoresAtributos: 'Atributos dinâmicos'
+  };
+
+  const chave = path.split('.')[0] || path;
+  return labels[chave] || path;
+}
+
+function diffRecursivo(
+  anterior: unknown,
+  atual: unknown,
+  pathAtual: string,
+  changes: MudancaDelta[]
+) {
+  if (JSON.stringify(anterior) === JSON.stringify(atual)) {
+    return;
+  }
+
+  if (Array.isArray(anterior) || Array.isArray(atual)) {
+    changes.push({
+      path: pathAtual,
+      op: anterior === undefined ? 'add' : atual === undefined ? 'remove' : 'replace',
+      before: anterior,
+      after: atual,
+      label: labelPorPath(pathAtual)
+    });
+    return;
+  }
+
+  if (isObject(anterior) && isObject(atual)) {
+    const keys = new Set([...Object.keys(anterior), ...Object.keys(atual)]);
+    for (const key of Array.from(keys).sort()) {
+      const proxPath = pathAtual ? `${pathAtual}.${key}` : key;
+      diffRecursivo(anterior[key], atual[key], proxPath, changes);
+    }
+    return;
+  }
+
+  changes.push({
+    path: pathAtual,
+    op: anterior === undefined ? 'add' : atual === undefined ? 'remove' : 'replace',
+    before: anterior,
+    after: atual,
+    label: labelPorPath(pathAtual)
+  });
+}
+
+export function gerarDeltaHistoricoProduto(anterior: unknown, atual: unknown): DeltaHistoricoProduto {
+  const changes: MudancaDelta[] = [];
+  diffRecursivo(anterior, atual, '', changes);
+
+  return {
+    schemaVersion: 1,
+    changes: changes.filter(change => change.path)
+  };
+}
+
+export function gerarResumoDelta(delta: DeltaHistoricoProduto, versaoSiscomex: number) {
+  if (!delta.changes.length) {
+    return `Versão ${versaoSiscomex} sem alterações de conteúdo.`;
+  }
+
+  if (versaoSiscomex <= 1) {
+    return 'Produto criado no SISCOMEX.';
+  }
+
+  return `${delta.changes.length} alteração(ões) na versão ${versaoSiscomex}.`;
+}

--- a/docs/HISTORICO_PRODUTO.md
+++ b/docs/HISTORICO_PRODUTO.md
@@ -1,0 +1,54 @@
+# Histórico de Versões de Produto (SISCOMEX)
+
+## Objetivo
+Registrar e exibir, por produto, o histórico de versões confirmadas com sucesso no SISCOMEX.
+
+## Escopo
+- O histórico pertence ao produto (`produto_id`).
+- Apenas versões criadas com sucesso são registradas.
+- Não inclui eventos de erro operacional.
+
+## Modelo de Persistência
+Tabela: `produto_historico_versao`.
+
+Campos principais:
+- `produto_id`
+- `versao_siscomex`
+- `tipo_evento` (`CRIACAO` ou `ATUALIZACAO`)
+- `delta_json`
+- `snapshot_json` (checkpoint periódico)
+- `is_checkpoint`
+- `transmissao_id`
+- `criado_em`
+
+## Contrato do Delta JSON
+```json
+{
+  "schemaVersion": 1,
+  "changes": [
+    {
+      "path": "denominacao",
+      "op": "replace",
+      "before": "texto anterior",
+      "after": "texto novo",
+      "label": "Denominação"
+    }
+  ]
+}
+```
+
+### Operações
+- `add`
+- `remove`
+- `replace`
+
+## Regras de Resumo
+- Versão 1: `Produto criado no SISCOMEX.`
+- Demais versões: `<N> alteração(ões) na versão <V>.`
+
+## API
+### `GET /api/v1/produtos/:id/historico`
+Retorna timeline ordenada por versão decrescente.
+
+## Frontend
+A tela de cadastro/edição do produto exibe a aba `Histórico` ao lado de `Atributos Dinâmicos`, listando versão, data e mudanças.

--- a/docs/sql/2026-03-04_produto_historico_versao.sql
+++ b/docs/sql/2026-03-04_produto_historico_versao.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS produto_historico_versao (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  produto_id INT NOT NULL,
+  versao_siscomex INT NOT NULL,
+  tipo_evento VARCHAR(30) NOT NULL,
+  resumo TEXT NULL,
+  delta_json JSON NULL,
+  snapshot_json JSON NULL,
+  is_checkpoint TINYINT(1) NOT NULL DEFAULT 0,
+  transmissao_id INT NULL,
+  criado_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_hist_produto
+    FOREIGN KEY (produto_id) REFERENCES produto(id)
+    ON DELETE CASCADE,
+  CONSTRAINT fk_hist_transmissao
+    FOREIGN KEY (transmissao_id) REFERENCES produto_transmissao(id)
+    ON DELETE SET NULL,
+  CONSTRAINT uk_hist_produto_versao
+    UNIQUE (produto_id, versao_siscomex)
+);
+
+CREATE INDEX idx_hist_produto_versao
+  ON produto_historico_versao (produto_id, versao_siscomex);
+
+CREATE INDEX idx_hist_produto_data
+  ON produto_historico_versao (produto_id, criado_em);
+
+CREATE INDEX idx_hist_transmissao
+  ON produto_historico_versao (transmissao_id);

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -67,6 +67,26 @@ interface AtributoParaIa {
   condicionanteCodigo?: string;
 }
 
+interface HistoricoMudanca {
+  path: string;
+  op: 'add' | 'remove' | 'replace';
+  before?: unknown;
+  after?: unknown;
+  label?: string;
+}
+
+interface HistoricoProdutoItem {
+  id: number;
+  versaoSiscomex: number;
+  tipoEvento: string;
+  resumo: string | null;
+  criadoEm: string;
+  delta: {
+    schemaVersion: number;
+    changes: HistoricoMudanca[];
+  } | null;
+}
+
 export default function ProdutoPage() {
   const [catalogoId, setCatalogoId] = useState('');
   const [catalogoNome, setCatalogoNome] = useState('');
@@ -93,6 +113,10 @@ export default function ProdutoPage() {
   const [estruturaCarregada, setEstruturaCarregada] = useState(false);
   const [activeTab, setActiveTab] = useState('informacoes');
   const [loading, setLoading] = useState(false);
+  const [historico, setHistorico] = useState<HistoricoProdutoItem[]>([]);
+  const [loadingHistorico, setLoadingHistorico] = useState(false);
+  const [historicoCarregado, setHistoricoCarregado] = useState(false);
+  const [historicoExpandido, setHistoricoExpandido] = useState<Record<number, boolean>>({});
   const { addToast } = useToast();
   const router = useRouter();
   const { id } = router.query;
@@ -137,6 +161,9 @@ export default function ProdutoPage() {
     setResumoSugestoesIa(null);
     setIaJaSolicitada(false);
     setLimpezaInicialIaRealizada(false);
+    setHistorico([]);
+    setHistoricoCarregado(false);
+    setHistoricoExpandido({});
   }, [id]);
 
   useEffect(() => {
@@ -878,6 +905,26 @@ export default function ProdutoPage() {
     }
   }, [router.isReady, id, isNew]);
 
+  useEffect(() => {
+    if (isNew || !id || activeTab !== 'historico' || historicoCarregado) return;
+
+    async function carregarHistorico() {
+      try {
+        setLoadingHistorico(true);
+        const resposta = await api.get<HistoricoProdutoItem[]>(`/produtos/${id}/historico`);
+        setHistorico(resposta.data || []);
+        setHistoricoCarregado(true);
+      } catch (error) {
+        console.error('Erro ao carregar histórico do produto:', error);
+        addToast('Erro ao carregar histórico do produto', 'error');
+      } finally {
+        setLoadingHistorico(false);
+      }
+    }
+
+    carregarHistorico();
+  }, [activeTab, id, isNew, historicoCarregado, addToast]);
+
   function coletarFaltantes(lista: AtributoEstrutura[]): AtributoEstrutura[] {
     const faltantes: AtributoEstrutura[] = [];
     for (const a of lista) {
@@ -1360,6 +1407,87 @@ export default function ProdutoPage() {
                           <div className="grid grid-cols-3 gap-4 text-sm">
                             {estrutura.map(attr => renderCampo(attr))}
                           </div>
+                        </div>
+                      )
+                    },
+                    {
+                      id: 'historico',
+                      label: 'Histórico',
+                      content: (
+                        <div className="flex flex-col gap-3">
+                          {loadingHistorico && (
+                            <p className="text-sm text-gray-400">Carregando histórico de versões...</p>
+                          )}
+
+                          {!loadingHistorico && historico.length === 0 && (
+                            <p className="text-sm text-gray-400">Nenhuma versão registrada para este produto.</p>
+                          )}
+
+                          {!loadingHistorico && historico.length > 0 && (
+                            <div className="flex flex-col gap-3">
+                              {historico.map(item => {
+                                const expandido = historicoExpandido[item.id] === true;
+                                const mudancas = item.delta?.changes || [];
+
+                                return (
+                                  <Card key={item.id} className="p-4">
+                                    <div className="flex items-start justify-between gap-3">
+                                      <div>
+                                        <p className="text-sm text-white font-medium">
+                                          Versão {item.versaoSiscomex} · {item.tipoEvento}
+                                        </p>
+                                        <p className="text-xs text-gray-400">
+                                          {new Date(item.criadoEm).toLocaleString('pt-BR')}
+                                        </p>
+                                        <p className="text-sm text-gray-300 mt-1">
+                                          {item.resumo || 'Alterações registradas na versão.'}
+                                        </p>
+                                      </div>
+
+                                      {mudancas.length > 0 && (
+                                        <Button
+                                          type="button"
+                                          variant="outline"
+                                          onClick={() => setHistoricoExpandido(prev => ({ ...prev, [item.id]: !expandido }))}
+                                        >
+                                          {expandido ? 'Ocultar mudanças' : 'Ver mudanças'}
+                                        </Button>
+                                      )}
+                                    </div>
+
+                                    {expandido && mudancas.length > 0 && (
+                                      <div className="mt-3 overflow-x-auto">
+                                        <table className="w-full text-xs text-left">
+                                          <thead className="text-gray-400 bg-[#0f1419] uppercase">
+                                            <tr>
+                                              <th className="px-3 py-2">Campo</th>
+                                              <th className="px-3 py-2">Operação</th>
+                                              <th className="px-3 py-2">Antes</th>
+                                              <th className="px-3 py-2">Depois</th>
+                                            </tr>
+                                          </thead>
+                                          <tbody>
+                                            {mudancas.map((mudanca, idx) => (
+                                              <tr key={`${item.id}-${idx}`} className="border-b border-gray-700">
+                                                <td className="px-3 py-2 text-gray-200">{mudanca.label || mudanca.path}</td>
+                                                <td className="px-3 py-2 text-gray-300">{mudanca.op}</td>
+                                                <td className="px-3 py-2 text-gray-400">
+                                                  {mudanca.before === undefined ? '-' : JSON.stringify(mudanca.before)}
+                                                </td>
+                                                <td className="px-3 py-2 text-gray-400">
+                                                  {mudanca.after === undefined ? '-' : JSON.stringify(mudanca.after)}
+                                                </td>
+                                              </tr>
+                                            ))}
+                                          </tbody>
+                                        </table>
+                                      </div>
+                                    )}
+                                  </Card>
+                                );
+                              })}
+                            </div>
+                          )}
                         </div>
                       )
                     }

--- a/frontend/pages/produtos/[id].tsx
+++ b/frontend/pages/produtos/[id].tsx
@@ -914,16 +914,23 @@ export default function ProdutoPage() {
         const resposta = await api.get<HistoricoProdutoItem[]>(`/produtos/${id}/historico`);
         setHistorico(resposta.data || []);
         setHistoricoCarregado(true);
-      } catch (error) {
+      } catch (error: any) {
+        if (error?.response?.status === 404) {
+          setHistorico([]);
+          setHistoricoCarregado(true);
+          return;
+        }
+
         console.error('Erro ao carregar histórico do produto:', error);
         addToast('Erro ao carregar histórico do produto', 'error');
+        setHistoricoCarregado(true);
       } finally {
         setLoadingHistorico(false);
       }
     }
 
     carregarHistorico();
-  }, [activeTab, id, isNew, historicoCarregado, addToast]);
+  }, [activeTab, id, isNew, historicoCarregado]);
 
   function coletarFaltantes(lista: AtributoEstrutura[]): AtributoEstrutura[] {
     const faltantes: AtributoEstrutura[] = [];


### PR DESCRIPTION
### Motivation
- Registrar e exibir histórico de versões confirmadas no SISCOMEX por produto para auditoria e inspeção de mudanças.
- Gerar e persistir deltas entre snapshots para economizar espaço e permitir visualização das alterações. 
- Expor o histórico via API para consumo pelo frontend e associar eventos a transmissões realizadas. 

### Description
- Adiciona o modelo `ProdutoHistoricoVersao` ao schema Prisma e relacionamentos com `Produto` e `ProdutoTransmissao`, além de índices e a coluna `transmissao_id`, e inclui a migração SQL em `docs/sql/2026-03-04_produto_historico_versao.sql`.
- Implementa utilitário de diff `backend/src/utils/produto-historico-diff.ts` que normaliza objetos, gera `DeltaHistoricoProduto` e produz resumos; inclui testes em `backend/src/utils/__tests__/produto-historico-diff.test.ts`.
- Estende `ProdutoService` com `obterSnapshotParaHistorico`, `registrarHistoricoVersao` e `listarHistorico`, altera `marcarComoTransmitido` para executar em transação, capturar snapshot anterior e registrar histórico; adapta chamada em `ProdutoTransmissaoService` para enviar `transmissaoId`.
- Expõe endpoint `GET /api/v1/produtos/:id/historico` via `produto.controller`/`produto.routes` (`obterHistoricoProduto`) e adiciona aba `Histórico` na UI `frontend/pages/produtos/[id].tsx` com carregamento, listagem e visualização detalhada das mudanças; adiciona documentação em `docs/HISTORICO_PRODUTO.md`.

### Testing
- Executado o teste unitário `produto-historico-diff.test.ts` via suíte de testes do projeto (`npm test`/Jest) e todas as asserções passaram.
- Tipagem e build básicos foram verificados durante desenvolvimento (TypeScript), sem erros de compilação nas unidades modificadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78c1319dc83308f5d59f00943e6c3)